### PR TITLE
Fix repository link in modelserver package's README

### DIFF
--- a/modelserver-theia/README.md
+++ b/modelserver-theia/README.md
@@ -1,5 +1,5 @@
 # Model Server Theia
-[Model server](https://github.com/eclipse/emfcloud-modelserver) integration for Theia
+[Model server](https://github.com/eclipse-emfcloud/emfcloud-modelserver-theia) integration for Theia
 
 ## Getting started
 


### PR DESCRIPTION
The link was pointing to the old repository.