### PR TITLE
Fixes #19, Fixes #20: Align client API with protocol

### DIFF
--- a/example/dev-example/src/browser/api-test-menu.ts
+++ b/example/dev-example/src/browser/api-test-menu.ts
@@ -41,46 +41,62 @@ export const GetAllCommand: Command = {
     id: 'ApiTest.GetAll',
     label: 'getAll()'
 };
+
+export const GetModelUrisCommand: Command = {
+    id: 'ApiTest.GetModelUris',
+    label: 'getModelUris()'
+};
+
 export const PatchCommand: Command = {
     id: 'ApiTest.Patch',
     label: 'patch(SuperBrewer3000.coffee)'
 };
+
 export const SubscribeCommand: Command = {
     id: 'ApiTest.Subscribe',
     label: 'subscribe(SuperBrewer3000.coffee)'
 };
+
 export const UnsubscribeCommand: Command = {
     id: 'ApiTest.Unsubscribe',
     label: 'unsubscribe(SuperBrewer3000.coffee)'
 };
+
 export const EditSetCommand: Command = {
     id: 'ApiTest.EditSet',
     label: 'edit(SuperBrewer3000.coffee,{type:set})'
 };
+
 export const EditAddCommand: Command = {
     id: 'ApiTest.EditAdd',
     label: 'edit(SuperBrewer3000.coffee,{type:add})'
 };
+
 export const EditRemoveCommand: Command = {
     id: 'ApiTest.EditRemove',
     label: 'edit(SuperBrewer3000.coffee,{type:remove})'
 };
+
 export const SaveCommand: Command = {
     id: 'ApiTest.Save',
     label: 'save(SuperBrewer3000.coffee)'
 };
+
 export const GetTypeSchemaCommand: Command = {
     id: 'ApiTest.GetTypeSchema',
     label: 'getTypeSchema(Coffee.ecore)'
 };
+
 export const GetUiSchemaCommand: Command = {
     id: 'ApiTest.GetUiSchema',
     label: 'getUiSchema(ControlUnitView)'
 };
+
 export const GetModelElementByIdCommand: Command = {
     id: 'ApiTest.GetModelElementById',
     label: 'getModelElementById(SuperBrewer3000.coffee, //@workflows.0)'
 };
+
 export const GetModelElementByNameCommand: Command = {
     id: 'ApiTest.GetModelElementByName',
     label: 'getModelElementByName(SuperBrewer3000.coffee, BrewingFlow)'
@@ -90,6 +106,7 @@ export const API_TEST_MENU = [...MAIN_MENU_BAR, '9_API_TEST_MENU'];
 export const PING = [...API_TEST_MENU, PingCommand.label];
 export const GET_MODEL = [...API_TEST_MENU, GetModelCommand.label];
 export const GET_ALL = [...API_TEST_MENU, GetAllCommand.label];
+export const GET_MODEL_URIS = [...API_TEST_MENU, GetModelUrisCommand.label];
 export const PATCH = [...API_TEST_MENU, PatchCommand.label];
 export const SUBSCRIBE = [...API_TEST_MENU, SubscribeCommand.label];
 export const UNSUBSCRIBE = [...API_TEST_MENU, UnsubscribeCommand.label];
@@ -159,7 +176,6 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 this.workspaceUri = e[0].uri.replace('file://', 'file:');
             }
         });
-
     }
 
     registerCommands(commands: CommandRegistry): void {
@@ -177,11 +193,17 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                     .then(response => this.messageService.info(printResponse(response)));
             }
         });
-
         commands.registerCommand(GetAllCommand, {
             execute: () => {
                 this.modelServerClient
                     .getAll()
+                    .then(response => this.messageService.info(printResponse(response)));
+            }
+        });
+        commands.registerCommand(GetModelUrisCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .getModelUris()
                     .then(response => this.messageService.info(printResponse(response)));
             }
         });
@@ -194,23 +216,14 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         });
         commands.registerCommand(SubscribeCommand, {
             execute: () => {
-                this.modelServerSubscriptionService.onOpenListener(() =>
-                    this.messageService.info('Subscription opened!')
-                );
+                this.modelServerSubscriptionService.onOpenListener(() => this.messageService.info('Subscription opened!'));
                 this.modelServerSubscriptionService.onDirtyStateListener(dirtyState => this.messageService.info(`DirtyState ${dirtyState}`));
-                this.modelServerSubscriptionService.onIncrementalUpdateListener(
-                    incrementalUpdate => this.messageService.info(`IncrementalUpdate ${JSON.stringify(incrementalUpdate)}`));
+                this.modelServerSubscriptionService.onIncrementalUpdateListener(update => this.messageService.info(`IncrementalUpdate ${JSON.stringify(update)}`));
                 this.modelServerSubscriptionService.onFullUpdateListener(fullUpdate => this.messageService.info(`FullUpdate ${JSON.stringify(fullUpdate)}`));
                 this.modelServerSubscriptionService.onSuccessListener(successMessage => this.messageService.info(`Success ${successMessage}`));
                 this.modelServerSubscriptionService.onUnknownMessageListener(message => this.messageService.warn(`Unknown Message ${JSON.stringify(message)}`));
-
-                this.modelServerSubscriptionService.onClosedListener(reason =>
-                    this.messageService.info(`Closed!
-        Reason: ${reason}`)
-                );
-                this.modelServerSubscriptionService.onErrorListener(error =>
-                    this.messageService.error(JSON.stringify(error))
-                );
+                this.modelServerSubscriptionService.onClosedListener(reason => this.messageService.info(`Closed! Reason: ${reason}`));
+                this.modelServerSubscriptionService.onErrorListener(error => this.messageService.error(JSON.stringify(error)));
                 this.modelServerClient.subscribe('SuperBrewer3000.coffee');
             }
         });
@@ -230,7 +243,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 const feature = 'name';
                 const changedValues = ['Auto Brew'];
                 const setCommand: ModelServerCommand = ModelServerCommandUtil.createSetCommand(owner, feature, changedValues);
-                this.modelServerClient.edit('SuperBrewer3000.coffee', setCommand);
+                this.modelServerClient
+                    .edit('SuperBrewer3000.coffee', setCommand)
+                    .then(response => this.messageService.info(printResponse(response)));
             }
         });
         commands.registerCommand(EditRemoveCommand, {
@@ -244,7 +259,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 const feature = 'nodes';
                 const indices = [0];
                 const removeCommand: ModelServerCommand = ModelServerCommandUtil.createRemoveCommand(owner, feature, indices);
-                this.modelServerClient.edit('SuperBrewer3000.coffee', removeCommand);
+                this.modelServerClient
+                    .edit('SuperBrewer3000.coffee', removeCommand)
+                    .then(response => this.messageService.info(printResponse(response)));
             }
         });
         commands.registerCommand(EditAddCommand, {
@@ -258,12 +275,16 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 const feature = 'nodes';
                 const toAdd = [{ eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask' }];
                 const addCommand: ModelServerCommand = ModelServerCommandUtil.createAddCommand(owner, feature, toAdd);
-                this.modelServerClient.edit('SuperBrewer3000.coffee', addCommand);
+                this.modelServerClient
+                    .edit('SuperBrewer3000.coffee', addCommand)
+                    .then(response => this.messageService.info(printResponse(response)));
             }
         });
         commands.registerCommand(SaveCommand, {
             execute: () => {
-                this.modelServerClient.save('SuperBrewer3000.coffee');
+                this.modelServerClient
+                    .save('SuperBrewer3000.coffee')
+                    .then(response => this.messageService.info(printResponse(response)));
             }
         });
 
@@ -302,6 +323,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(API_TEST_MENU, { commandId: PingCommand.id });
         menus.registerMenuAction(API_TEST_MENU, { commandId: GetModelCommand.id });
         menus.registerMenuAction(API_TEST_MENU, { commandId: GetAllCommand.id });
+        menus.registerMenuAction(API_TEST_MENU, { commandId: GetModelUrisCommand.id });
         menus.registerMenuAction(API_TEST_MENU, { commandId: PatchCommand.id });
         menus.registerMenuAction(API_TEST_MENU, { commandId: SubscribeCommand.id });
         menus.registerMenuAction(API_TEST_MENU, { commandId: UnsubscribeCommand.id });

--- a/modelserver-theia/src/common/model-server-client.ts
+++ b/modelserver-theia/src/common/model-server-client.ts
@@ -46,13 +46,19 @@ export interface ModelServerFrontendClient {
     onError(error: Error): void;
 }
 
+export interface Model {
+    modelUri: string;
+    content: string;
+}
+
 export const ModelServerClient = Symbol('ModelServerClient');
 export interface ModelServerClient
     extends JsonRpcServer<ModelServerFrontendClient> {
     initialize(): Promise<boolean>;
 
     get(modelUri: string): Promise<Response<string>>;
-    getAll(): Promise<Response<string[] | string>>;
+    getAll(): Promise<Response<Model[]>>;
+    getModelUris(): Promise<Response<string[]>>;
 
     getElementById(modelUri: string, elementid: string): Promise<Response<string>>;
     getElementByName(modelUri: string, elementname: string): Promise<Response<string>>;
@@ -70,10 +76,7 @@ export interface ModelServerClient
     subscribe(modelUri: string): void;
     unsubscribe(modelUri: string): void;
 
-    edit(
-        modelUri: string,
-        command: ModelServerCommand
-    ): Promise<Response<boolean>>;
+    edit(modelUri: string, command: ModelServerCommand): Promise<Response<boolean>>;
 
     getTypeSchema(modelUri: string): Promise<Response<string>>;
     getUiSchema(schemaName: string): Promise<Response<string>>;
@@ -87,6 +90,7 @@ export interface LaunchOptions {
     jarPath?: string;
     additionalArgs?: string[];
 }
+
 export const DEFAULT_LAUNCH_OPTIONS: LaunchOptions = {
     baseURL: 'api/v1',
     serverPort: 8081,
@@ -97,6 +101,49 @@ export interface ServerConfiguration {
     workspaceRoot: string;
     uiSchemaFolder?: string;
 }
+
+export type ResponseBody = ModelServerMessage;
+
+export namespace ResponseBody {
+    export function asString(body: ResponseBody): string {
+        return body.data as string;
+    }
+
+    export function asStringArray(body: ResponseBody): string[] {
+        return body.data as string[];
+    }
+
+    export function asBoolean(body: ResponseBody): boolean {
+        return Boolean(asObject(body));
+    }
+
+    export function asObject(body: ResponseBody): object {
+        return JSON.parse(body.data.toString());
+    }
+
+    export function asModelArray(body: ResponseBody): Model[] {
+        return Object.entries(body.data).map(ResponseBody.asModel);
+    }
+
+    export function asModel(data: [string, string]): Model {
+        return { modelUri: data[0], content: data[1] } as Model;
+    }
+
+    export function isSuccess(body: ResponseBody): boolean {
+        return body.type === 'success';
+    }
+}
+
+export namespace RequestBody {
+    export function fromData(data: any): string {
+        return from({ data });
+    }
+
+    export function from(object: any): string {
+        return JSON.stringify(object);
+    }
+}
+
 export class Response<T> {
     constructor(
         readonly body: T,
@@ -108,3 +155,4 @@ export class Response<T> {
         return new Response(mapper(this.body), this.statusCode, this.statusMessage);
     }
 }
+

--- a/modelserver-theia/src/node/modelserver-api.ts
+++ b/modelserver-theia/src/node/modelserver-api.ts
@@ -111,7 +111,7 @@ export class DefaultModelServerClient implements ModelServerClient {
     }
 
     async getUiSchema(schemaName: string): Promise<Response<string>> {
-        const response = await this.restClient.get(`${ModelServerPaths.UI_SCHEMA}?schemaName=${schemaName}`);
+        const response = await this.restClient.get(`${ModelServerPaths.UI_SCHEMA}?schemaname=${schemaName}`);
         return response.mapBody(ResponseBody.asString);
     }
 

--- a/modelserver-theia/src/node/rest-client.ts
+++ b/modelserver-theia/src/node/rest-client.ts
@@ -16,14 +16,14 @@ const fetch = require('node-fetch');
 /**
  * A simple helper class for performing REST requests
  */
-export class RestClient {
+export class RestClient<BODY> {
     constructor(protected baseUrl: string) { }
 
-    private async performRequest<T>(
+    private async performRequest(
         verb: string,
         path: string,
         body?: string
-    ): Promise<Response<T>> {
+    ): Promise<Response<BODY>> {
         const response = await fetch(this.baseUrl + path, {
             headers: {
                 'Accept': 'application/json',
@@ -32,44 +32,44 @@ export class RestClient {
             method: verb,
             body
         });
-        const json = (await response.json()) as T;
+        const json = (await response.json()) as BODY;
         return new Response(json, response.status, response.statusText);
     }
 
-    async get<T>(
+    async get(
         path: string,
         parameters?: Map<string, string>
-    ): Promise<Response<T>> {
+    ): Promise<Response<BODY>> {
         let getUrl = path;
         if (parameters) {
             const urlParameters = this.encodeURLParameters(parameters);
             getUrl = getUrl.concat(urlParameters);
         }
-        return this.performRequest<T>('get', getUrl);
+        return this.performRequest('get', getUrl);
     }
 
-    async post<T>(url: string, body?: string): Promise<Response<T>> {
-        return this.performRequest<T>('post', url, body);
+    async post(url: string, body?: string): Promise<Response<BODY>> {
+        return this.performRequest('post', url, body);
     }
 
-    async put<T>(url: string, body?: string): Promise<Response<T>> {
-        return this.performRequest<T>('PUT', url, body);
+    async put(url: string, body?: string): Promise<Response<BODY>> {
+        return this.performRequest('PUT', url, body);
     }
 
-    async patch<T>(url: string, body?: string): Promise<Response<T>> {
-        return this.performRequest<T>('patch', url, body);
+    async patch(url: string, body?: string): Promise<Response<BODY>> {
+        return this.performRequest('patch', url, body);
     }
 
-    async remove<T>(
+    async remove(
         url: string,
         parameters?: Map<string, string>
-    ): Promise<Response<T>> {
+    ): Promise<Response<BODY>> {
         let deleteUrl = url;
         if (parameters) {
             const urlParameters = this.encodeURLParameters(parameters);
             deleteUrl = deleteUrl.concat(urlParameters);
         }
-        return this.performRequest<T>('delete', deleteUrl);
+        return this.performRequest('delete', deleteUrl);
     }
 
     private encodeURLParameters(parameters: Map<string, string>): string {


### PR DESCRIPTION
- Add missing method for listing model uris: getModelUris
-- Add to example API test menu

- Ensure getAll returns a list of model
-- Introduce dedicated model type with modelUri and content properties

- Clean up code and use more types

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>