### PR TITLE
Prolong WebSocket connections via timeout and keepAlive messages

### DIFF
--- a/modelserver-theia/src/browser/model-server-frontend-client.ts
+++ b/modelserver-theia/src/browser/model-server-frontend-client.ts
@@ -34,7 +34,8 @@ export class ModelServerFrontendClientImpl implements ModelServerFrontendClient,
                 this.onIncrementalUpdateEmitter.fire(message.data);
                 break;
             }
-            case 'success': {
+            case 'success':
+            case 'keepAlive': {
                 this.onSuccessEmitter.fire(message.data);
                 break;
             }
@@ -49,7 +50,16 @@ export class ModelServerFrontendClientImpl implements ModelServerFrontendClient,
     }
 
     onClosed(code: number, reason: string): void {
-        this.onClosedEmitter.fire(reason);
+        let closeReason = reason;
+        switch (code) {
+            case 1005: {
+                closeReason = 'Connection closed by peer'; break;
+            }
+            case 1006: {
+                closeReason = 'Server shutdown'; break;
+            }
+        }
+        this.onClosedEmitter.fire(code + ': ' + closeReason);
     }
 
     onError(error: Error): void {

--- a/modelserver-theia/src/common/model-server-client.ts
+++ b/modelserver-theia/src/common/model-server-client.ts
@@ -79,7 +79,8 @@ export interface ModelServerClient
     getUiSchema(schemaName: string): Promise<Response<string>>;
 
     // WebSocket connection
-    subscribe(modelUri: string, timeout?: number): void;
+    subscribe(modelUri: string): void;
+    subscribeWithTimeout(modelUri: string, timeout: number): void;
     sendKeepAlive(modelUri: string): void;
     unsubscribe(modelUri: string): void;
 }

--- a/modelserver-theia/src/common/model-server-client.ts
+++ b/modelserver-theia/src/common/model-server-client.ts
@@ -32,7 +32,7 @@ export interface ModelServerCommand {
 }
 
 export interface ModelServerMessage {
-    type: 'dirtyState' | 'incrementalUpdate' | 'fullUpdate' | 'success' | 'error';
+    type: 'dirtyState' | 'incrementalUpdate' | 'fullUpdate' | 'success' | 'error' | 'keepAlive';
     data: any;
 }
 export const ModelServerFrontendClient = Symbol('ModelServerFrontendClient');
@@ -72,14 +72,16 @@ export interface ModelServerClient
     save(modelUri: string): Promise<Response<boolean>>;
 
     getLaunchOptions(): Promise<LaunchOptions>;
-    // subscribe
-    subscribe(modelUri: string): void;
-    unsubscribe(modelUri: string): void;
 
     edit(modelUri: string, command: ModelServerCommand): Promise<Response<boolean>>;
 
     getTypeSchema(modelUri: string): Promise<Response<string>>;
     getUiSchema(schemaName: string): Promise<Response<string>>;
+
+    // WebSocket connection
+    subscribe(modelUri: string, timeout?: number): void;
+    sendKeepAlive(modelUri: string): void;
+    unsubscribe(modelUri: string): void;
 }
 
 export const LaunchOptions = Symbol('LaunchOptions');

--- a/modelserver-theia/src/node/modelserver-api.ts
+++ b/modelserver-theia/src/node/modelserver-api.ts
@@ -116,9 +116,18 @@ export class DefaultModelServerClient implements ModelServerClient {
         return response.mapBody(ResponseBody.asString);
     }
 
-    subscribe(modelUri: string, timeout?: number): void {
-        const path = `${this.baseUrl}${ModelServerPaths.SUBSCRIPTION}?modeluri=${modelUri}${timeout ? '&timeout=' + timeout : ''}`;
-        const socket = new WebSocket(path);
+    subscribe(modelUri: string): void {
+        const path = `${this.baseUrl}${ModelServerPaths.SUBSCRIPTION}?modeluri=${modelUri}`;
+        this.doSubscribe(modelUri, path);
+    }
+
+    subscribeWithTimeout(modelUri: string, timeout: number): void {
+        const path = `${this.baseUrl}${ModelServerPaths.SUBSCRIPTION}?modeluri=${modelUri}&timeout=${timeout}`;
+        this.doSubscribe(modelUri, path);
+    }
+
+    private doSubscribe(modelUri: string, path: string): void {
+        const socket = new WebSocket(path.trim());
         socket.on('message', data => this.client.onMessage(JSON.parse(data.toString())));
         socket.on('close', (code, reason) => this.client.onClosed(code, reason));
         socket.on('error', error => this.client.onError(error));


### PR DESCRIPTION
- Structure ModelServer test menu for better overview
- Add all possible subsription scenarios to ModelServer test menu
  - Subscribe without explicit timeout
     - Session does not time out and is open until explicitly closed via unsubscribe.
  - Subscribe with timeout 60s and keep alive messages
     - Session is opened with a timeout of 60s and client sends keep alive messages to keep session opened every 59s until excplicitly closed via unsubscribe.
  - Subscribe with timeout 10s
    - Session is opened with a timeout of 10s and is closed if idle timeout is reached; user may send keep alive messages manually and unsubscribe within the defined timeout.

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>