### PR TITLE
Add validation endpoint examples

### DIFF
--- a/example/dev-example/src/browser/api-test-menu.ts
+++ b/example/dev-example/src/browser/api-test-menu.ts
@@ -127,6 +127,16 @@ export const SaveCoffeeEcoreCommand: Command = {
     label: 'save(Coffee.ecore)'
 };
 
+export const ValidationCoffeeEcoreCommand: Command = {
+    id: 'ApiTest.Validation.CoffeeEcore',
+    label: 'validate(Coffee.ecore)'
+};
+
+export const ValidationConstraintsCoffeeEcoreCommand: Command = {
+    id: 'ApiTest.ValidationConstraints.CoffeeEcore',
+    label: 'validationConstraints(Coffee.ecore)'
+};
+
 export const SubscribeAndKeepAliveCommand: Command = {
     id: 'ApiTest.SubscribeAndKeepAlive',
     label: 'subscribeAndKeepAlive(Coffee.ecore, 60000)'
@@ -193,6 +203,16 @@ export const SaveCommand: Command = {
     label: 'save(SuperBrewer3000.coffee)'
 };
 
+export const ValidationCommand: Command = {
+    id: 'ApiTest.Validation.SuperBrewer3000',
+    label: 'validate(SuperBrewer3000.coffee)'
+};
+
+export const ValidationConstraintsCommand: Command = {
+    id: 'ApiTest.ValidationConstraints.SuperBrewer3000',
+    label: 'validationConstraints(SuperBrewer3000.coffee)'
+};
+
 export const SubscribeCommand: Command = {
     id: 'ApiTest.Subscribe.SuperBrewer3000',
     label: 'subscribe(SuperBrewer3000.coffee)'
@@ -249,6 +269,16 @@ export const SaveSuperBrewer3000JsonCommand: Command = {
     label: 'save(SuperBrewer3000.json)'
 };
 
+export const ValidationSuperBrewer3000JsonCommand: Command = {
+    id: 'ApiTest.Validation.SuperBrewer3000Json',
+    label: 'validate(SuperBrewer3000.json)'
+};
+
+export const ValidationConstraintsSuperBrewer3000JsonCommand: Command = {
+    id: 'ApiTest.ValidationConstraints.SuperBrewer3000Json',
+    label: 'validationConstraints(SuperBrewer3000.json)'
+};
+
 export const SubscribeWithTimeoutCommand: Command = {
     id: 'ApiTest.SubscribeWithTimeout',
     label: 'subscribeWithTimeout(SuperBrewer3000.json, 10000)'
@@ -276,21 +306,24 @@ export const COFFEE_TEST_MENU = [...MAIN_MENU_BAR, '9_1_API_TEST_MENU_COFFEE'];
 export const COFFEE_GET_SECTION = [...COFFEE_TEST_MENU, '1_API_MENU_COFFEE_GET_SECTION'];
 export const COFFEE_EDIT_SECTION = [...COFFEE_TEST_MENU, '2_API_MENU_COFFEE_EDIT_SECTION'];
 export const COFFEE_SAVE_SECTION = [...COFFEE_TEST_MENU, '3_API_MENU_COFFEE_SAVE_SECTION'];
-export const COFFEE_WEBSOCKET_SECTION = [...COFFEE_TEST_MENU, '4_API_MENU_COFFEE_WEBSOCKET_SECTION'];
+export const COFFEE_VALIDATION_SECTION = [...COFFEE_TEST_MENU, '4_API_MENU_COFFEE_VALIDATION_SECTION'];
+export const COFFEE_WEBSOCKET_SECTION = [...COFFEE_TEST_MENU, '5_API_MENU_COFFEE_WEBSOCKET_SECTION'];
 
 /* SuperBrewer3000.coffee menu */
 export const SUPERBREWER_TEST_MENU = [...MAIN_MENU_BAR, '9_2_API_TEST_MENU_SUPERBREWER'];
 export const SUPERBREWER_GET_SECTION = [...SUPERBREWER_TEST_MENU, '1_API_MENU_SUPERBREWER_GET_SECTION'];
 export const SUPERBREWER_EDIT_SECTION = [...SUPERBREWER_TEST_MENU, '2_API_MENU_SUPERBREWER_EDIT_SECTION'];
 export const SUPERBREWER_SAVE_SECTION = [...SUPERBREWER_TEST_MENU, '3_API_MENU_SUPERBREWER_SAVE_SECTION'];
-export const SUPERBREWER_WEBSOCKET_SECTION = [...SUPERBREWER_TEST_MENU, '4_API_MENU_SUPERBREWER_WEBSOCKET_SECTION'];
+export const SUPERBREWER_VALIDATION_SECTION = [...SUPERBREWER_TEST_MENU, '4_API_MENU_SUPERBREWER_VALIDATION_SECTION'];
+export const SUPERBREWER_WEBSOCKET_SECTION = [...SUPERBREWER_TEST_MENU, '5_API_MENU_SUPERBREWER_WEBSOCKET_SECTION'];
 
 /* SuperBrewer3000.json menu */
 export const SUPERBREWER_JSON_TEST_MENU = [...MAIN_MENU_BAR, '9_3_API_TEST_MENU_SUPERBREWER_JSON'];
 export const SUPERBREWER_JSON_GET_SECTION = [...SUPERBREWER_JSON_TEST_MENU, '1_API_MENU_SUPERBREWER_JSON_GET_SECTION'];
 export const SUPERBREWER_JSON_EDIT_SECTION = [...SUPERBREWER_JSON_TEST_MENU, '2_API_MENU_SUPERBREWER_JSON_EDIT_SECTION'];
 export const SUPERBREWER_JSON_SAVE_SECTION = [...SUPERBREWER_JSON_TEST_MENU, '3_API_MENU_SUPERBREWER_JSON_SAVE_SECTION'];
-export const SUPERBREWER_JSON_WEBSOCKET_SECTION = [...SUPERBREWER_JSON_TEST_MENU, '4_API_MENU_SUPERBREWER_JSON_WEBSOCKET_SECTION'];
+export const SUPERBREWER_JSON_VALIDATION_SECTION = [...SUPERBREWER_JSON_TEST_MENU, '4_API_MENU_SUPERBREWER_JSON_VALIDATION_SECTION'];
+export const SUPERBREWER_JSON_WEBSOCKET_SECTION = [...SUPERBREWER_JSON_TEST_MENU, '5_API_MENU_SUPERBREWER_JSON_WEBSOCKET_SECTION'];
 
 const superBrewer3000JsonPatch = {
     'eClass':
@@ -497,6 +530,20 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
+        commands.registerCommand(ValidationCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .validation('Coffee.ecore')
+                    .then((response: any) => this.messageService.info(printResponse(response)));
+            }
+        });
+        commands.registerCommand(ValidationConstraintsCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .validationConstraints('Coffee.ecore')
+                    .then((response: any) => this.messageService.info(printResponse(response)));
+            }
+        });
         commands.registerCommand(SubscribeCommand, {
             execute: () => {
                 this.modelServerClient.subscribe('SuperBrewer3000.coffee');
@@ -649,6 +696,20 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
+        commands.registerCommand(ValidationCoffeeEcoreCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .validation('Coffee.ecore')
+                    .then((response: any) => this.messageService.info(printResponse(response)));
+            }
+        });
+        commands.registerCommand(ValidationConstraintsCoffeeEcoreCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .validationConstraints('Coffee.ecore')
+                    .then((response: any) => this.messageService.info(printResponse(response)));
+            }
+        });
         commands.registerCommand(SubscribeAndKeepAliveCommand, {
             execute: () => {
                 this.modelServerClient.subscribeWithTimeout('Coffee.ecore', 60000);
@@ -756,6 +817,20 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
+        commands.registerCommand(ValidationSuperBrewer3000JsonCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .validation('SuperBrewer3000.json')
+                    .then((response: any) => this.messageService.info(printResponse(response)));
+            }
+        });
+        commands.registerCommand(ValidationConstraintsSuperBrewer3000JsonCommand, {
+            execute: () => {
+                this.modelServerClient
+                    .validationConstraints('SuperBrewer3000.json')
+                    .then((response: any) => this.messageService.info(printResponse(response)));
+            }
+        });
         commands.registerCommand(SubscribeWithTimeoutCommand, {
             execute: () => {
                 this.modelServerClient.subscribeWithTimeout('SuperBrewer3000.json', 10000);
@@ -806,6 +881,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(COFFEE_SAVE_SECTION, { commandId: UndoCoffeeEcoreCommand.id });
         menus.registerMenuAction(COFFEE_SAVE_SECTION, { commandId: RedoCoffeeEcoreCommand.id });
 
+        menus.registerMenuAction(COFFEE_VALIDATION_SECTION, { commandId: ValidationCoffeeEcoreCommand.id });
+        menus.registerMenuAction(COFFEE_VALIDATION_SECTION, { commandId: ValidationConstraintsCoffeeEcoreCommand.id });
+
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeAndKeepAliveCommand.id });
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeAndKeepAliveXmiCommand.id });
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: UnsubscribeKeepAliveCommand.id });
@@ -826,6 +904,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(SUPERBREWER_SAVE_SECTION, { commandId: UndoCommand.id });
         menus.registerMenuAction(SUPERBREWER_SAVE_SECTION, { commandId: RedoCommand.id });
 
+        menus.registerMenuAction(SUPERBREWER_VALIDATION_SECTION, { commandId: ValidationCommand.id });
+        menus.registerMenuAction(SUPERBREWER_VALIDATION_SECTION, { commandId: ValidationConstraintsCommand.id });
+
         menus.registerMenuAction(SUPERBREWER_WEBSOCKET_SECTION, { commandId: SubscribeCommand.id });
         menus.registerMenuAction(SUPERBREWER_WEBSOCKET_SECTION, { commandId: UnsubscribeCommand.id });
 
@@ -843,6 +924,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(SUPERBREWER_JSON_SAVE_SECTION, { commandId: SaveSuperBrewer3000JsonCommand.id });
         menus.registerMenuAction(SUPERBREWER_JSON_SAVE_SECTION, { commandId: UndoSuperBrewer3000JsonCommand.id });
         menus.registerMenuAction(SUPERBREWER_JSON_SAVE_SECTION, { commandId: RedoSuperBrewer3000JsonCommand.id });
+
+        menus.registerMenuAction(SUPERBREWER_JSON_VALIDATION_SECTION, { commandId: ValidationSuperBrewer3000JsonCommand.id });
+        menus.registerMenuAction(SUPERBREWER_JSON_VALIDATION_SECTION, { commandId: ValidationConstraintsSuperBrewer3000JsonCommand.id });
 
         menus.registerMenuAction(SUPERBREWER_JSON_WEBSOCKET_SECTION, { commandId: SubscribeWithTimeoutCommand.id, order: 'a' });
         menus.registerMenuAction(SUPERBREWER_JSON_WEBSOCKET_SECTION, { commandId: KeepSubscriptionAliveCommand.id, order: 'b' });

--- a/example/dev-example/src/browser/api-test-menu.ts
+++ b/example/dev-example/src/browser/api-test-menu.ts
@@ -137,6 +137,11 @@ export const ValidationConstraintsCoffeeEcoreCommand: Command = {
     label: 'validationConstraints(Coffee.ecore)'
 };
 
+export const SubscribeWithValidationCoffeeEcoreCommand: Command = {
+    id: 'ApiTest.SubscribeWithValidation',
+    label: 'subscribeWithValidation(Coffee.ecore)'
+};
+
 export const SubscribeAndKeepAliveCommand: Command = {
     id: 'ApiTest.SubscribeAndKeepAlive',
     label: 'subscribeAndKeepAlive(Coffee.ecore, 60000)'
@@ -213,6 +218,11 @@ export const ValidationConstraintsCommand: Command = {
     label: 'validationConstraints(SuperBrewer3000.coffee)'
 };
 
+export const SubscribeWithValidationCommand: Command = {
+    id: 'ApiTest.SubscribeWithValidation.SuperBrewer3000',
+    label: 'subscribeWithValidation(SuperBrewer3000.coffee)'
+};
+
 export const SubscribeCommand: Command = {
     id: 'ApiTest.Subscribe.SuperBrewer3000',
     label: 'subscribe(SuperBrewer3000.coffee)'
@@ -277,6 +287,11 @@ export const ValidationSuperBrewer3000JsonCommand: Command = {
 export const ValidationConstraintsSuperBrewer3000JsonCommand: Command = {
     id: 'ApiTest.ValidationConstraints.SuperBrewer3000Json',
     label: 'validationConstraints(SuperBrewer3000.json)'
+};
+
+export const SubscribeWithValidationSuperBrewer3000JsonCommand: Command = {
+    id: 'ApiTest.SubscribeWithValidation.SuperBrewer3000Json',
+    label: 'subscribeWithValidation(SuperBrewer3000.json)'
 };
 
 export const SubscribeWithTimeoutCommand: Command = {
@@ -533,20 +548,25 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationCommand, {
             execute: () => {
                 this.modelServerClient
-                    .validation('Coffee.ecore')
+                    .validation('SuperBrewer3000.coffee')
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
         commands.registerCommand(ValidationConstraintsCommand, {
             execute: () => {
                 this.modelServerClient
-                    .validationConstraints('Coffee.ecore')
+                    .validationConstraints('SuperBrewer3000.coffee')
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
         commands.registerCommand(SubscribeCommand, {
             execute: () => {
                 this.modelServerClient.subscribe('SuperBrewer3000.coffee');
+            }
+        });
+        commands.registerCommand(SubscribeWithValidationCommand, {
+            execute: () => {
+                this.modelServerClient.subscribeWithValidation('SuperBrewer3000.coffee');
             }
         });
         commands.registerCommand(UnsubscribeCommand, {
@@ -710,6 +730,11 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
+        commands.registerCommand(SubscribeWithValidationCoffeeEcoreCommand, {
+            execute: () => {
+                this.modelServerClient.subscribeWithValidation('Coffee.ecore');
+            }
+        });
         commands.registerCommand(SubscribeAndKeepAliveCommand, {
             execute: () => {
                 this.modelServerClient.subscribeWithTimeout('Coffee.ecore', 60000);
@@ -831,6 +856,11 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
         });
+        commands.registerCommand(SubscribeWithValidationSuperBrewer3000JsonCommand, {
+            execute: () => {
+                this.modelServerClient.subscribeWithValidation('SuperBrewer3000.json');
+            }
+        });
         commands.registerCommand(SubscribeWithTimeoutCommand, {
             execute: () => {
                 this.modelServerClient.subscribeWithTimeout('SuperBrewer3000.json', 10000);
@@ -885,6 +915,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(COFFEE_VALIDATION_SECTION, { commandId: ValidationConstraintsCoffeeEcoreCommand.id });
 
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeAndKeepAliveCommand.id });
+        menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeWithValidationCoffeeEcoreCommand.id });
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeAndKeepAliveXmiCommand.id });
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: UnsubscribeKeepAliveCommand.id });
 
@@ -908,6 +939,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(SUPERBREWER_VALIDATION_SECTION, { commandId: ValidationConstraintsCommand.id });
 
         menus.registerMenuAction(SUPERBREWER_WEBSOCKET_SECTION, { commandId: SubscribeCommand.id });
+        menus.registerMenuAction(SUPERBREWER_WEBSOCKET_SECTION, { commandId: SubscribeWithValidationCommand.id });
         menus.registerMenuAction(SUPERBREWER_WEBSOCKET_SECTION, { commandId: UnsubscribeCommand.id });
 
         /* SuperBrewer3000.json */
@@ -929,6 +961,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(SUPERBREWER_JSON_VALIDATION_SECTION, { commandId: ValidationConstraintsSuperBrewer3000JsonCommand.id });
 
         menus.registerMenuAction(SUPERBREWER_JSON_WEBSOCKET_SECTION, { commandId: SubscribeWithTimeoutCommand.id, order: 'a' });
+        menus.registerMenuAction(SUPERBREWER_JSON_WEBSOCKET_SECTION, { commandId: SubscribeWithValidationSuperBrewer3000JsonCommand.id });
         menus.registerMenuAction(SUPERBREWER_JSON_WEBSOCKET_SECTION, { commandId: KeepSubscriptionAliveCommand.id, order: 'b' });
         menus.registerMenuAction(SUPERBREWER_JSON_WEBSOCKET_SECTION, { commandId: UnsubscribeTimeoutCommand.id, order: 'c' });
 

--- a/example/dev-example/src/browser/api-test-menu.ts
+++ b/example/dev-example/src/browser/api-test-menu.ts
@@ -992,6 +992,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         this.modelServerSubscriptionService.onErrorListener((response: ModelServerMessage) => {
             this.showSocketError(`Error! ${JSON.stringify(response.data)}`, response.modelUri);
         });
+        this.modelServerSubscriptionService.onValidationResultListener((response: ModelServerMessage) => {
+            this.showSocketInfo(`Validation result ${JSON.stringify(response.data)}`, response.modelUri);
+        });
     }
 
     private showSocketInfo(message: string, modelUri = ''): void {

--- a/modelserver-theia/src/browser/model-server-subscription-client.ts
+++ b/modelserver-theia/src/browser/model-server-subscription-client.ts
@@ -53,6 +53,10 @@ export class ModelServerSubscriptionClient implements ModelServerFrontendClient,
                 this.onErrorEmitter.fire(message);
                 break;
             }
+            case 'validationResult': {
+                this.onValidationResultEmitter.fire(message);
+                break;
+            }
             default: {
                 this.onUnknownMessageEmitter.fire(message);
             }
@@ -112,5 +116,10 @@ export class ModelServerSubscriptionClient implements ModelServerFrontendClient,
     protected onUnknownMessageEmitter = new Emitter<Readonly<ModelServerMessage>>();
     get onUnknownMessageListener(): Event<ModelServerMessage> {
         return this.onUnknownMessageEmitter.event;
+    }
+
+    protected onValidationResultEmitter = new Emitter<Readonly<ModelServerMessage>>();
+    get onValidationResultListener(): Event<ModelServerMessage> {
+        return this.onValidationResultEmitter.event;
     }
 }

--- a/modelserver-theia/src/common/model-server-api.ts
+++ b/modelserver-theia/src/common/model-server-api.ts
@@ -85,6 +85,7 @@ export interface ModelServerSubscriptionService {
     readonly onFullUpdateListener: Event<ModelServerMessage>;
     readonly onSuccessListener: Event<ModelServerMessage>;
     readonly onUnknownMessageListener: Event<ModelServerMessage>;
+    readonly onValidationResultListener: Event<ModelServerMessage>;
 }
 
 export const ModelServerClient = Symbol('ModelServerClient');
@@ -156,7 +157,7 @@ export interface ModelServerResponse {
 }
 
 export interface ModelServerMessage extends ModelServerResponse {
-    type: 'dirtyState' | 'incrementalUpdate' | 'fullUpdate' | 'success' | 'error' | 'keepAlive';
+    type: 'dirtyState' | 'incrementalUpdate' | 'fullUpdate' | 'success' | 'error' | 'keepAlive' | 'validationResult';
 }
 
 export type ResponseBody = ModelServerMessage;

--- a/modelserver-theia/src/common/model-server-api.ts
+++ b/modelserver-theia/src/common/model-server-api.ts
@@ -117,6 +117,9 @@ export interface ModelServerClient extends JsonRpcServer<ModelServerFrontendClie
     getTypeSchema(modelUri: string): Promise<Response<string>>;
     getUiSchema(schemaName: string): Promise<Response<string>>;
 
+    validation(modelUri: string): Promise<Response<string>>;
+    validationConstraints(modelUri: string): Promise<Response<string>>;
+
     // WebSocket connection
     subscribe(modelUri: string): void;
     subscribeWithFormat(modelUri: string, format: string): void;

--- a/modelserver-theia/src/common/model-server-api.ts
+++ b/modelserver-theia/src/common/model-server-api.ts
@@ -122,6 +122,7 @@ export interface ModelServerClient extends JsonRpcServer<ModelServerFrontendClie
 
     // WebSocket connection
     subscribe(modelUri: string): void;
+    subscribeWithValidation(modelUri: string): void;
     subscribeWithFormat(modelUri: string, format: string): void;
     subscribeWithTimeout(modelUri: string, timeout: number): void;
     subscribeWithTimeoutAndFormat(modelUri: string, timeout: number, format: string): void;

--- a/modelserver-theia/src/common/model-server-paths.ts
+++ b/modelserver-theia/src/common/model-server-paths.ts
@@ -32,4 +32,7 @@ export namespace ModelServerPaths {
     export const UNDO = 'undo';
     export const REDO = 'redo';
 
+    export const VALIDATION = 'validation';
+    export const VALIDATION_CONSTRAINTS = 'validation/constraints';
+
 }

--- a/modelserver-theia/src/node/model-server-client.ts
+++ b/modelserver-theia/src/node/model-server-client.ts
@@ -148,6 +148,11 @@ export class DefaultModelServerClient implements ModelServerClient {
         this.doSubscribe(modelUri, path);
     }
 
+    subscribeWithValidation(modelUri: string): void {
+        const path = `${this.baseUrl}${ModelServerPaths.SUBSCRIPTION}?modeluri=${modelUri}&livevalidation=true`;
+        this.doSubscribe(modelUri, path);
+    }
+
     subscribeWithFormat(modelUri: string, format: string): void {
         const path = `${this.baseUrl}${ModelServerPaths.SUBSCRIPTION}?modeluri=${modelUri}&format=${format}`;
         this.doSubscribe(modelUri, path);

--- a/modelserver-theia/src/node/model-server-client.ts
+++ b/modelserver-theia/src/node/model-server-client.ts
@@ -133,6 +133,16 @@ export class DefaultModelServerClient implements ModelServerClient {
         return response.mapBody(ResponseBody.asString);
     }
 
+    async validation(modelUri: string): Promise<Response<string>> {
+        const response = await this.restClient.get(`${ModelServerPaths.VALIDATION}?modeluri=${modelUri}`);
+        return response.mapBody(ResponseBody.asString);
+    }
+
+    async validationConstraints(modelUri: string): Promise<Response<string>> {
+        const response = await this.restClient.get(`${ModelServerPaths.VALIDATION_CONSTRAINTS}?modeluri=${modelUri}`);
+        return response.mapBody(ResponseBody.asString);
+    }
+
     subscribe(modelUri: string): void {
         const path = `${this.baseUrl}${ModelServerPaths.SUBSCRIPTION}?modeluri=${modelUri}`;
         this.doSubscribe(modelUri, path);


### PR DESCRIPTION
Adds examples for the functionalities introduced in [this PR](https://github.com/eclipse-emfcloud/emfcloud-modelserver/pull/43/)

Signed-off-by: Simon Graband <simon.graband@tum.de>