### PR TITLE
Fixes #38: Provide more utility methods for commands

### DIFF
--- a/example/dev-example/src/browser/api-test-menu.ts
+++ b/example/dev-example/src/browser/api-test-menu.ts
@@ -8,17 +8,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
+import { DiagnosticManager } from '@eclipse-emfcloud/modelserver-markers-theia/lib/browser';
+import { Diagnostic } from '@eclipse-emfcloud/modelserver-theia/lib/browser';
 import {
-    ModelServerCommand,
-    ModelServerCommandUtil,
-    ModelServerCompoundCommand,
+    AddCommand,
+    CommandExecutionResult,
+    CompoundCommand,
     ModelServerMessage,
     ModelServerResponse,
     ModelServerSubscriptionService,
-    Response
+    RemoveCommand,
+    Response,
+    SetCommand
 } from '@eclipse-emfcloud/modelserver-theia/lib/common';
-import { Diagnostic } from '@eclipse-emfcloud/modelserver-theia/lib/browser';
-import { DiagnosticManager } from '@eclipse-emfcloud/modelserver-markers-theia/lib/browser';
 import {
     Command,
     CommandContribution,
@@ -32,7 +34,7 @@ import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { inject, injectable, postConstruct } from 'inversify';
 
-import { DevModelServerClient, DevModelServerCommandUtil } from '../common/dev-model-server-client';
+import { DevModelServerClient, UpdateTaskNameCommand } from '../common/dev-model-server-client';
 
 /* ModelServer commands */
 export const PingCommand: Command = {
@@ -534,7 +536,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'name';
                 const changedValues = ['Auto Brew'];
-                const setCommand: ModelServerCommand = ModelServerCommandUtil.createSetCommand(owner, feature, changedValues);
+                const setCommand = new SetCommand(owner, feature, changedValues);
                 this.modelServerClient
                     .edit('SuperBrewer3000.coffee', setCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -550,7 +552,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'nodes';
                 const indices = [0];
-                const removeCommand: ModelServerCommand = ModelServerCommandUtil.createRemoveCommand(owner, feature, indices);
+                const removeCommand = new RemoveCommand(owner, feature, indices);
                 this.modelServerClient
                     .edit('SuperBrewer3000.coffee', removeCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -566,7 +568,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'nodes';
                 const toAdd = [{ eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask' }];
-                const addCommand: ModelServerCommand = ModelServerCommandUtil.createAddCommand(owner, feature, toAdd);
+                const addCommand = new AddCommand(owner, feature, toAdd);
                 this.modelServerClient
                     .edit('SuperBrewer3000.coffee', addCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -693,7 +695,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const featureA = 'name';
                 const changedValuesA = ['ControlUnitNew'];
-                const setCommandA: ModelServerCommand = ModelServerCommandUtil.createSetCommand(ownerA, featureA, changedValuesA);
+                const setCommandA = new SetCommand(ownerA, featureA, changedValuesA);
 
                 const ownerB = {
                     'eClass':
@@ -703,9 +705,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const featureB = 'name';
                 const changedValuesB = ['WaterTankNew'];
-                const setCommandB: ModelServerCommand = ModelServerCommandUtil.createSetCommand(ownerB, featureB, changedValuesB);
+                const setCommandB = new SetCommand(ownerB, featureB, changedValuesB);
 
-                const compoundCommand: ModelServerCompoundCommand = ModelServerCommandUtil.createCompoundCommand([setCommandA, setCommandB]);
+                const compoundCommand = new CompoundCommand([setCommandA, setCommandB]);
 
                 this.modelServerClient
                     .edit('Coffee.ecore', compoundCommand)
@@ -722,7 +724,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'name';
                 const changedValues = ['ControlUnitNew'];
-                const setCommand: ModelServerCommand = ModelServerCommandUtil.createSetCommand(owner, feature, changedValues);
+                const setCommand = new SetCommand(owner, feature, changedValues);
                 this.modelServerClient
                     .edit('Coffee.ecore', setCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -738,7 +740,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'eClassifiers';
                 const indices = [5];
-                const removeCommand: ModelServerCommand = ModelServerCommandUtil.createRemoveCommand(owner, feature, indices);
+                const removeCommand = new RemoveCommand(owner, feature, indices);
                 this.modelServerClient
                     .edit('Coffee.ecore', removeCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -754,7 +756,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'eClassifiers';
                 const toAdd = [{ eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EClass', name: 'NewEClassifier' }];
-                const addCommand: ModelServerCommand = ModelServerCommandUtil.createAddCommand(owner, feature, toAdd);
+                const addCommand = new AddCommand(owner, feature, toAdd);
                 this.modelServerClient
                     .edit('Coffee.ecore', addCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -858,7 +860,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'name';
                 const changedValues = ['Auto Brew'];
-                const setCommand: ModelServerCommand = ModelServerCommandUtil.createSetCommand(owner, feature, changedValues);
+                const setCommand = new SetCommand(owner, feature, changedValues);
                 this.modelServerClient
                     .edit('SuperBrewer3000.json', setCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -874,7 +876,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'nodes';
                 const indices = [0];
-                const removeCommand: ModelServerCommand = ModelServerCommandUtil.createRemoveCommand(owner, feature, indices);
+                const removeCommand = new RemoveCommand(owner, feature, indices);
                 this.modelServerClient
                     .edit('SuperBrewer3000.json', removeCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -890,7 +892,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 };
                 const feature = 'nodes';
                 const toAdd = [{ eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask' }];
-                const addCommand: ModelServerCommand = ModelServerCommandUtil.createAddCommand(owner, feature, toAdd);
+                const addCommand = new AddCommand(owner, feature, toAdd);
                 this.modelServerClient
                     .edit('SuperBrewer3000.json', addCommand)
                     .then((response: any) => this.messageService.info(printResponse(response)));
@@ -898,7 +900,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         });
         commands.registerCommand(UpdateTaskNameSuperBrewer3000JsonCustomCommand, {
             execute: () => {
-                const updateTaskName = DevModelServerCommandUtil.createUpdateTaskNameCommand('Coffee');
+                const updateTaskName = new UpdateTaskNameCommand('Coffee');
                 this.modelServerClient.edit('SuperBrewer3000.json', updateTaskName)
                     .then((response: any) => this.messageService.info(printResponse(response)));
             }
@@ -1093,6 +1095,11 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             this.showSocketInfo(`DirtyState ${response.data}`, response.modelUri);
         });
         this.modelServerSubscriptionService.onIncrementalUpdateListener((response: ModelServerMessage) => {
+            const data = response.data;
+            // show-case type casting from server data
+            if (CommandExecutionResult.is(data)) {
+                console.log(`Incremental update due to command execution: Reason '${data.type}' based on command '${data.source.type}'`);
+            }
             this.showSocketInfo(`IncrementalUpdate ${JSON.stringify(response.data)}`, response.modelUri);
         });
         this.modelServerSubscriptionService.onFullUpdateListener((response: ModelServerMessage) => {

--- a/example/dev-example/src/common/dev-model-server-client.ts
+++ b/example/dev-example/src/common/dev-model-server-client.ts
@@ -15,13 +15,8 @@ export interface DevModelServerClient extends ModelServerClient {
     counter(operation: 'add' | 'subtract' | undefined, delta: number | undefined): Promise<Response<string>>;
 }
 
-export namespace DevModelServerCommandUtil {
-    export function createUpdateTaskNameCommand(text: string): ModelServerCommand {
-        return {
-            eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//Command',
-            type: 'updateTaskName',
-            properties: { text }
-        };
-    }    
+export class UpdateTaskNameCommand extends ModelServerCommand {
+    constructor(text: string) {
+        super('updateTaskName', { text });
+    }
 }
-

--- a/modelserver-theia/README.md
+++ b/modelserver-theia/README.md
@@ -29,7 +29,7 @@ export interface ModelServerClient extends JsonRpcServer<ModelServerFrontendClie
 
     getLaunchOptions(): Promise<LaunchOptions>;
 
-    edit(modelUri: string, command: ModelServerCommand | ModelServerCompoundCommand): Promise<Response<boolean>>;
+    edit(modelUri: string, command: ModelServerCommand): Promise<Response<boolean>>;
 
     getTypeSchema(modelUri: string): Promise<Response<string>>;
     getUiSchema(schemaName: string): Promise<Response<string>>;
@@ -83,7 +83,7 @@ const toAdd = [
         eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask'
     }
 ];
-const addCommand: ModelServerCommand = ModelServerCommandUtil.createAddCommand(owner, feature, toAdd);
+const addCommand = new AddCommand(owner, feature, toAdd);
 this.modelServerClient.edit('SuperBrewer3000.json', addCommand)
     .then((response: any) => this.messageService.info("INCREMENTAL UPDATE: " + response.body()));
 

--- a/modelserver-theia/src/common/base-model.ts
+++ b/modelserver-theia/src/common/base-model.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+
+export type DataValueType = boolean | number | string;
+
+export class ModelServerObject {
+    readonly eClass: string;
+
+    static is(object?: any): object is ModelServerObject {
+        return object !== undefined && object.eClass !== undefined && typeof object.eClass === 'string';
+    }
+}
+
+export class ModelServerReferenceDescription extends ModelServerObject {
+    constructor(public eClass: string, public $ref: string) {
+        super();
+    }
+}

--- a/modelserver-theia/src/common/change-model.ts
+++ b/modelserver-theia/src/common/change-model.ts
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+import { ModelServerObject, ModelServerReferenceDescription } from './base-model';
+
+export namespace ChangePackage {
+    export const NS_URI = 'http://www.eclipse.org/emf/2003/Change';
+
+    export enum ChangeKind {
+        ADD, REMOVE, MOVE
+    }
+}
+
+export class FeatureMapEntry extends ModelServerObject {
+    static readonly URI = ChangePackage.NS_URI + '#//FeatureMapEntry';
+    eClass = FeatureMapEntry.URI;
+
+    featureName?: string;
+    dataValue?: string;
+    value?: any;
+    feature: any;
+    referenceValue?: any;
+
+    static is(object?: any): object is FeatureMapEntry {
+        return ModelServerObject.is(object) && object.eClass === FeatureMapEntry.URI;
+    }
+}
+
+export class ListChange {
+    kind?: ChangePackage.ChangeKind;
+    dataValues?: string[];
+    index?: number = -1;
+    moveToIndex?: number;
+    values?: any[];
+    referenceValues?: ModelServerReferenceDescription[];
+    feature?: any;
+    featureMapEntryValues?: FeatureMapEntry[];
+}
+
+export class ResourceChange extends ModelServerObject {
+    static readonly URI = ChangePackage.NS_URI + '#//ResourceChange';
+    eClass = ResourceChange.URI;
+
+    resourceURI?: string;
+    resource?: any;
+    value?: any;
+    listChanges?: ListChange[];
+
+    static is(object?: any): object is ResourceChange {
+        return ModelServerObject.is(object) && object.eClass === ResourceChange.URI;
+    }
+}
+
+export class FeatureChange {
+    static readonly URI = ChangePackage.NS_URI + '#//FeatureChange';
+    eClass = ChangeDescription.URI;
+
+    featureName?: string;
+    dataValue?: string;
+    set?: boolean;
+    value?: any;
+    feature?: ModelServerReferenceDescription;
+    referenceValue?: ModelServerReferenceDescription;
+    listChanges?: ListChange[];
+}
+
+export class EObjectToChangesMapEntry extends ModelServerObject {
+    static readonly URI = ChangePackage.NS_URI + '#//EObjectToChangesMapEntry';
+    eClass = ChangeDescription.URI;
+
+    key: ModelServerReferenceDescription;
+    value?: FeatureChange[];
+
+    static is(object?: any): object is EObjectToChangesMapEntry {
+        return ModelServerObject.is(object) && object.eClass === EObjectToChangesMapEntry.URI
+            && 'key' in object && ModelServerReferenceDescription.is(object['key']);
+    }
+}
+
+export class ChangeDescription extends ModelServerObject {
+    static readonly URI = ChangePackage.NS_URI + '#//ChangeDescription';
+    eClass = ChangeDescription.URI;
+
+    objectsChanges?: EObjectToChangesMapEntry[];
+    objectsToDetach?: ModelServerObject[];
+    objectsToAttach?: ModelServerObject[];
+    resourceChanges?: ResourceChange[];
+
+    static is(object?: any): object is ChangeDescription {
+        return ModelServerObject.is(object) && object.eClass === ChangeDescription.URI;
+    }
+}
+

--- a/modelserver-theia/src/common/command-model.ts
+++ b/modelserver-theia/src/common/command-model.ts
@@ -1,0 +1,149 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+import { DataValueType, ModelServerObject, ModelServerReferenceDescription } from './base-model';
+import { ChangeDescription } from './change-model';
+import { isModelServerObjectArray, isModelServerReferenceDescriptionArray, isNumberArray } from './model-server-util';
+
+export namespace ModelServerCommandPackage {
+    export const NS_URI = 'http://www.eclipse.org/emfcloud/modelserver/command';
+}
+
+export class ModelServerCommand extends ModelServerObject {
+    static readonly URI = ModelServerCommandPackage.NS_URI + '#//Command';
+    eClass = ModelServerCommand.URI;
+
+    owner?: ModelServerReferenceDescription;
+    feature?: string;
+    indices?: number[];
+    dataValues?: DataValueType[];
+    objectValues?: ModelServerReferenceDescription[];
+    objectsToAdd?: ModelServerObject[];
+
+    constructor(public type: string, public properties?: { [key: string]: string }) {
+        super();
+    }
+
+    public setProperty(key: string, value: string): void {
+        if (this.properties === undefined) {
+            this.properties = {};
+        }
+        this.properties[key] = value;
+    }
+
+    public getProperty(key: string): undefined | string {
+        return this.properties && this.properties[key];
+    }
+
+    static is(object?: any): object is ModelServerCommand {
+        return ModelServerObject.is(object) && object.eClass === ModelServerCommand.URI
+            && 'type' in object && typeof object['type'] === 'string';
+    }
+}
+
+export class CompoundCommand extends ModelServerCommand {
+    static readonly TYPE = 'compound';
+    static readonly URI = ModelServerCommandPackage.NS_URI + '#//CompoundCommand';
+    eClass = CompoundCommand.URI;
+
+    constructor(public commands: ModelServerCommand[] = []) {
+        super(CompoundCommand.TYPE);
+    }
+
+    static is(object?: any): object is ModelServerCommand {
+        return ModelServerObject.is(object) && object.eClass === CompoundCommand.URI
+            && 'type' in object && typeof object['type'] === 'string' && object['type'] === CompoundCommand.TYPE
+            && 'commands' in object;
+    }
+}
+
+export class RemoveCommand extends ModelServerCommand {
+    static readonly TYPE = 'remove';
+
+    constructor(owner: ModelServerReferenceDescription, feature: string, indices: number[]);
+    constructor(owner: ModelServerReferenceDescription, feature: string, objectValues: ModelServerReferenceDescription[]);
+    constructor(public owner: ModelServerReferenceDescription, public feature: string, toDelete: number[] | ModelServerReferenceDescription[]) {
+        super(RemoveCommand.TYPE);
+        if (isNumberArray(toDelete)) {
+            this.indices = toDelete;
+        } else {
+            this.objectValues = toDelete;
+        }
+    }
+
+    static is(object?: any): object is ModelServerCommand {
+        return ModelServerCommand.is(object) && object.type === RemoveCommand.TYPE;
+    }
+}
+
+export class AddCommand extends ModelServerCommand {
+    static readonly TYPE = 'add';
+
+    constructor(owner: ModelServerReferenceDescription, feature: string, toAdd: DataValueType[] | ModelServerObject[]);
+    constructor(owner: ModelServerReferenceDescription, feature: string, toAdd: DataValueType[] | ModelServerObject[], index: number);
+    constructor(public owner: ModelServerReferenceDescription, public feature: string, toAdd: DataValueType[] | ModelServerObject[], index?: number) {
+        super(AddCommand.TYPE);
+        if (index) {
+            this.indices = [index];
+        }
+        if (isModelServerObjectArray(toAdd)) {
+            const objectValues: ModelServerReferenceDescription[] = toAdd.map((o, i) => new ModelServerReferenceDescription(o.eClass, `//@objectsToAdd.${i}`));
+            this.objectsToAdd = toAdd;
+            this.objectValues = objectValues;
+        } else {
+            this.dataValues = toAdd;
+        }
+    }
+
+    static is(object?: any): object is ModelServerCommand {
+        return ModelServerCommand.is(object) && object.type === AddCommand.TYPE;
+    }
+}
+
+export class SetCommand extends ModelServerCommand {
+    static readonly TYPE = 'set';
+
+    constructor(public owner: ModelServerReferenceDescription, public feature: string, changedValues: DataValueType[] | ModelServerReferenceDescription[]) {
+        super(SetCommand.TYPE);
+        if (isModelServerReferenceDescriptionArray(changedValues)) {
+            this.objectValues = changedValues;
+        } else {
+            this.dataValues = changedValues;
+        }
+    }
+
+    static is(object?: any): object is ModelServerCommand {
+        return ModelServerCommand.is(object) && object.type === SetCommand.TYPE;
+    }
+}
+
+export namespace CommandExecutionType {
+    export const EXECCUTE = 'execute';
+    export const UNDO = 'undo';
+    export const REDO = 'redo';
+}
+
+export class CommandExecutionResult implements ModelServerObject {
+    static readonly URI = ModelServerCommandPackage.NS_URI + '#//CommandExecutionResult';
+    eClass = CommandExecutionResult.URI;
+
+    affectedObjects?: ModelServerReferenceDescription[];
+    details?: { [key: string]: string };
+
+    constructor(public type: string, public source: ModelServerCommand, public changeDescription: ChangeDescription) {
+    }
+
+    static is(object?: any): object is CommandExecutionResult {
+        return ModelServerObject.is(object) && object.eClass === CommandExecutionResult.URI
+            && 'type' in object && typeof object['type'] === 'string'
+            && 'source' in object
+            && 'changeDescription' in object && ChangeDescription.is(object['changeDescription']);
+    }
+}

--- a/modelserver-theia/src/common/index.ts
+++ b/modelserver-theia/src/common/index.ts
@@ -9,6 +9,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 
+export * from './base-model';
+export * from './change-model';
+export * from './command-model';
 export * from './model-server-api';
 export * from './model-server-paths';
 export * from './model-server-util';

--- a/modelserver-theia/src/common/model-server-api.ts
+++ b/modelserver-theia/src/common/model-server-api.ts
@@ -11,35 +11,9 @@
 import { Event, JsonRpcServer } from '@theia/core';
 import * as WebSocket from 'ws';
 
+import { ModelServerCommand } from './command-model';
+
 export const MODEL_SERVER_CLIENT_SERVICE_PATH = '/services/modelserverclient';
-
-export type DataValueType = boolean | number | string;
-
-export interface ModelServerObject {
-    eClass: string;
-}
-
-export interface ModelServerReferenceDescription extends ModelServerObject {
-    $ref: string;
-}
-
-export interface ModelServerCommand {
-    eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//Command';
-    type: string;
-    owner?: ModelServerReferenceDescription;
-    feature?: string;
-    indices?: number[];
-    dataValues?: DataValueType[];
-    objectValues?: ModelServerReferenceDescription[];
-    objectsToAdd?: ModelServerObject[];
-    properties?: { [key: string]: string };
-}
-
-export interface ModelServerCompoundCommand {
-    eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//CompoundCommand';
-    type: 'compound';
-    commands: (ModelServerCommand | ModelServerCompoundCommand)[];
-}
 
 export interface WebSocketEvent {
     target?: WebSocket;
@@ -114,7 +88,7 @@ export interface ModelServerClient extends JsonRpcServer<ModelServerFrontendClie
 
     getLaunchOptions(): Promise<LaunchOptions>;
 
-    edit(modelUri: string, command: ModelServerCommand | ModelServerCompoundCommand): Promise<Response<boolean>>;
+    edit(modelUri: string, command: ModelServerCommand): Promise<Response<boolean>>;
 
     getTypeSchema(modelUri: string): Promise<Response<string>>;
     getUiSchema(schemaName: string): Promise<Response<string>>;

--- a/modelserver-theia/src/common/model-server-util.ts
+++ b/modelserver-theia/src/common/model-server-util.ts
@@ -8,92 +8,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
-import {
-    DataValueType,
-    ModelServerCommand,
-    ModelServerCompoundCommand,
-    ModelServerObject,
-    ModelServerReferenceDescription
-} from './model-server-api';
+import { DataValueType, ModelServerObject, ModelServerReferenceDescription } from './base-model';
 
-const isNumberArray =
-    (array: number[] | ModelServerReferenceDescription[]): array is number[] => array.every((e: number | ModelServerReferenceDescription) => typeof e === 'number');
+export function isNumberArray(array: number[] | ModelServerReferenceDescription[]): array is number[] {
+    return array.every((e: number | ModelServerReferenceDescription) => typeof e === 'number');
+}
 
-const isModelServerObjectArray =
-    (array: DataValueType[] | ModelServerObject[]): array is ModelServerObject[] => array.every((e: any) => typeof e === 'object' && e.eClass !== undefined);
+export function isModelServerObjectArray(array: DataValueType[] | ModelServerObject[]): array is ModelServerObject[] {
+    return array.every(ModelServerObject.is);
+}
 
-const isModelServerReferenceDescriptionArray = (array: DataValueType[] | ModelServerReferenceDescription[]):
-    array is ModelServerReferenceDescription[] => array.every((e: any) => typeof e === 'object' && e.eClass !== undefined && e.$ref !== undefined);
-
-export namespace ModelServerCommandUtil {
-    export function createRemoveCommand(owner: ModelServerReferenceDescription, feature: string, indices: number[]): ModelServerCommand;
-    export function createRemoveCommand(owner: ModelServerReferenceDescription, feature: string, objectValues: ModelServerReferenceDescription[]): ModelServerCommand;
-    export function createRemoveCommand(owner: ModelServerReferenceDescription, feature: string, toDelete: number[] | ModelServerReferenceDescription[]): ModelServerCommand {
-        let command: ModelServerCommand;
-        if (isNumberArray(toDelete)) {
-            command = {
-                eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//Command',
-                type: 'remove',
-                owner,
-                feature,
-                indices: toDelete
-            };
-        } else {
-            command = {
-                eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//Command',
-                type: 'remove',
-                owner,
-                feature,
-                objectValues: toDelete
-            };
-        }
-        return command;
-    }
-
-    export function createAddCommand(owner: ModelServerReferenceDescription, feature: string, toAdd: DataValueType[] | ModelServerObject[]): ModelServerCommand;
-    export function createAddCommand(owner: ModelServerReferenceDescription, feature: string, toAdd: DataValueType[] | ModelServerObject[], index: number): ModelServerCommand;
-    export function createAddCommand(owner: ModelServerReferenceDescription, feature: string, toAdd: DataValueType[] | ModelServerObject[], index?: number): ModelServerCommand {
-        const command: ModelServerCommand = {
-            eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//Command',
-            type: 'add',
-            owner,
-            feature
-        };
-        if (index !== undefined) {
-            command.indices = [index];
-        }
-        if (isModelServerObjectArray(toAdd)) {
-            const objectValues: ModelServerReferenceDescription[] = toAdd.map((o, i) => ({ eClass: o.eClass, $ref: `//@objectsToAdd.${i}` }));
-            command.objectsToAdd = toAdd;
-            command.objectValues = objectValues;
-        } else {
-            command.dataValues = toAdd;
-        }
-        return command;
-    }
-
-    export function createSetCommand(
-        owner: ModelServerReferenceDescription, feature: string, changedValues: DataValueType[] | ModelServerReferenceDescription[]): ModelServerCommand {
-        const command: ModelServerCommand = {
-            eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//Command',
-            type: 'set',
-            owner,
-            feature
-        };
-        if (isModelServerReferenceDescriptionArray(changedValues)) {
-            command.objectValues = changedValues;
-        } else {
-            command.dataValues = changedValues;
-        }
-        return command;
-    }
-
-    export function createCompoundCommand(commands: (ModelServerCommand | ModelServerCompoundCommand)[]): ModelServerCompoundCommand {
-        const compoundCommand: ModelServerCompoundCommand = {
-            eClass: 'http://www.eclipsesource.com/schema/2019/modelserver/command#//CompoundCommand',
-            type: 'compound',
-            commands
-        };
-        return compoundCommand;
-    }
+export function isModelServerReferenceDescriptionArray(array: DataValueType[] | ModelServerReferenceDescription[]): array is ModelServerReferenceDescription[] {
+    return array.every(ModelServerReferenceDescription.is);
 }

--- a/modelserver-theia/src/node/model-server-client.ts
+++ b/modelserver-theia/src/node/model-server-client.ts
@@ -17,7 +17,6 @@ import {
     Model,
     ModelServerClient,
     ModelServerCommand,
-    ModelServerCompoundCommand,
     ModelServerFrontendClient,
     ModelServerMessage,
     ModelServerPaths,
@@ -118,7 +117,7 @@ export class DefaultModelServerClient implements ModelServerClient {
         return response.mapBody(ResponseBody.isSuccess);
     }
 
-    async edit(modelUri: string, command: ModelServerCommand | ModelServerCompoundCommand): Promise<Response<boolean>> {
+    async edit(modelUri: string, command: ModelServerCommand): Promise<Response<boolean>> {
         const response = await this.restClient.patch(`${ModelServerPaths.COMMANDS}?modeluri=${modelUri}`, RequestBody.fromData(command));
         return response.mapBody(ResponseBody.isSuccess);
     }


### PR DESCRIPTION
- Provide classes instead of interfaces for model server commands
- Provide type guards for classes to evaluate data from server
- Add types for CommandExecutionResult and related classes

Part of emfcloud-modelserver/issues/87
- Adapt command URI to updated URI

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>