### PR TITLE
#150 Provide Client API V2 and Client implementation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,32 @@
         "--config",
         "${workspaceFolder}/configs/.mocharc.json",
         "--no-timeouts",
-        "${workspaceFolder}/packages/*/src/**/*.spec.ts"
+        "--extension",
+        "spec.ts",
+        "${workspaceFolder}/packages/*/src",
+        "--recursive",
+      ],
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run all unit tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--config",
+        "${workspaceFolder}/configs/.mocharc.json",
+        "--no-timeouts",
+        "--extension",
+        "spec.ts",
+        "${workspaceFolder}/packages/*/src",
+        "--recursive",
+        "--ignore",
+        "**/*integration.spec.ts"
       ],
       "env": {
         "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"

--- a/packages/modelserver-client/package.json
+++ b/packages/modelserver-client/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "events": "^3.3.0",
+    "fast-json-patch": "^3.1.0",
     "ws": "^7.4.6",
     "isomorphic-ws": "^4.0.1"
   },

--- a/packages/modelserver-client/src/index.ts
+++ b/packages/modelserver-client/src/index.ts
@@ -9,7 +9,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *********************************************************************************/
 export * from './model-server-client';
+export * from './model-server-client-v2';
 export * from './model-server-client-api-v1';
+export * from './model-server-client-api-v2';
 export * from './model-server-notification';
 export * from './model-server-paths';
 export * from './model-server-message';
@@ -20,4 +22,4 @@ export * from './model/diagnostic';
 export * from './subscription-listener';
 export * from './utils/model-server-utils';
 export * from './utils/type-util';
-
+export * from './utils/patch-utils';

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -87,9 +87,9 @@ export interface ModelServerClientApiV2 {
     edit(modeluri: string, patch: Operation | Operation[], format?: Format): Promise<ModelUpdateResult>;
     edit(modeluri: string, command: ModelServerCommand, format?: Format): Promise<ModelUpdateResult>;
 
-    undo(modeluri: string): Promise<string>;
+    undo(modeluri: string): Promise<ModelUpdateResult>;
 
-    redo(modeluri: string): Promise<string>;
+    redo(modeluri: string): Promise<ModelUpdateResult>;
 
     // WebSocket connection
     subscribe(modeluri: string, listener: SubscriptionListener, options?: SubscriptionOptions): SubscriptionListener;
@@ -114,6 +114,11 @@ export interface ModelUpdateResult {
      * A function to update the model. Only present if the edit request was successful.
      * The function can be applied to the original model (before edition) and will return
      * the new model (after edition).
+     *
+     * @param oldModel the model to patch
+     * @param copy by default, the patch will be directly applied to the oldModel, modifying
+     * it in-place. If copy is true, the patch will be applied on a copy of the model, leaving
+     * the original model unchanged.
      */
-    patch?(oldModel: ModelServerElement): ModelServerElement;
+    patch?(oldModel: ModelServerElement, copy?: boolean): ModelServerElement;
 }

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -12,6 +12,7 @@ import { Operation } from 'fast-json-patch';
 
 import { ServerConfiguration, SubscriptionOptions } from './model-server-client-api-v1';
 import { Model, ModelServerMessage } from './model-server-message';
+import { ModelServerElement } from './model/base-model';
 import { ModelServerCommand } from './model/command-model';
 import { Diagnostic } from './model/diagnostic';
 import { SubscriptionListener } from './subscription-listener';
@@ -83,8 +84,8 @@ export interface ModelServerClientApiV2 {
 
     ping(): Promise<boolean>;
 
-    edit(modeluri: string, patch: Operation | Operation[], format?: Format): Promise<boolean>;
-    edit(modeluri: string, command: ModelServerCommand, format?: Format): Promise<boolean>;
+    edit(modeluri: string, patch: Operation | Operation[], format?: Format): Promise<ModelUpdateResult>;
+    edit(modeluri: string, command: ModelServerCommand, format?: Format): Promise<ModelUpdateResult>;
 
     undo(modeluri: string): Promise<string>;
 
@@ -99,4 +100,20 @@ export interface ModelServerClientApiV2 {
 
 export namespace ModelServerClientApiV2 {
     export const API_ENDPOINT = '/api/v2';
+}
+
+/**
+ * Result sent to client after requesting a model update.
+ */
+export interface ModelUpdateResult {
+    /**
+     * True if the edit request was successful, false otherwise.
+     */
+    success: boolean;
+    /**
+     * A function to update the model. Only present if the edit request was successful.
+     * The function can be applied to the original model (before edition) and will return
+     * the new model (after edition).
+     */
+    patch?(oldModel: ModelServerElement): ModelServerElement;
 }

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -1,0 +1,101 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+import { Operation } from 'fast-json-patch';
+
+import { ServerConfiguration, SubscriptionOptions } from './model-server-client-api-v1';
+import { Model, ModelServerMessage } from './model-server-message';
+import { ModelServerCommand } from './model/command-model';
+import { Diagnostic } from './model/diagnostic';
+import { SubscriptionListener } from './subscription-listener';
+import { AnyObject, TypeGuard } from './utils/type-util';
+
+/**
+ * Basic client API to interact with a model server that conforms to the Modelserver API Version 2.
+ */
+export interface ModelServerClientApiV2 {
+    /**
+     * The `initialize` method should be executed before any other requests to the model server.
+     * The given base url should point to the location of the model server API entry point.
+     * (e.g. `http://localhost:8081/api/v1/`). Once the initialization is completed the client is expected
+     * to be ready and should be able to handle REST requests to & responses from the model server.
+     * Any requests to the model server before the client has been initialized are expected to fail (i.e. throw an error)
+     * @param baseUrl Url pointing to the API entry point
+     * @param defaultFormat Optional fallback format that should used when a request method is invoked and no explicit format argument
+     *                      has been passed.
+     */
+    initialize(baseUrl: string, defaultFormat?: string): void | Promise<void>;
+
+    /**
+     * Retrieves all available models of the current workspace.
+     * @param format
+     */
+    getAll(): Promise<Model[]>;
+    /**
+     * 3
+     * @param format
+     */
+    getAll<M>(typeGuard: TypeGuard<M>): Promise<Model<M>[]>;
+    getAll(format: string): Promise<Model<string>[]>;
+
+    get(modeluri: string, format?: string): Promise<AnyObject>;
+    get<M>(modeluri: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+
+    getModelUris(): Promise<string[]>;
+
+    getElementById(modeluri: string, elementid: string, format?: string): Promise<AnyObject>;
+    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+
+    getElementByName(modeluri: string, elementname: string, format?: string): Promise<AnyObject>;
+    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+
+    delete(modeluri: string): Promise<boolean>;
+
+    close(modeluri: string): Promise<boolean>;
+
+    create(modeluri: string, model: AnyObject | string, format?: string): Promise<AnyObject>;
+    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+
+    update(modeluri: string, model: AnyObject | string, format?: string): Promise<AnyObject>;
+    update<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+
+    save(modeluri: string): Promise<boolean>;
+
+    saveAll(): Promise<boolean>;
+
+    validate(modeluri: string): Promise<Diagnostic>;
+
+    getValidationConstraints(modeluri: string): Promise<string>;
+
+    getTypeSchema(modeluri: string): Promise<string>;
+
+    getUiSchema(schemaname: string): Promise<string>;
+
+    configureServer(configuration: ServerConfiguration): Promise<boolean>;
+
+    ping(): Promise<boolean>;
+
+    edit(modeluri: string, patch: Operation | Operation[], format?: string): Promise<boolean>;
+    edit(modeluri: string, command: ModelServerCommand, format?: string): Promise<boolean>;
+
+    undo(modeluri: string): Promise<string>;
+
+    redo(modeluri: string): Promise<string>;
+
+    // WebSocket connection
+    subscribe(modeluri: string, listener: SubscriptionListener, options?: SubscriptionOptions): SubscriptionListener;
+
+    send(modelUri: string, message: ModelServerMessage): void;
+    unsubscribe(modelUri: string): void;
+}
+
+export namespace ModelServerClientApiV2 {
+    export const API_ENDPOINT = '/api/v2';
+}

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -17,6 +17,12 @@ import { Diagnostic } from './model/diagnostic';
 import { SubscriptionListener } from './subscription-listener';
 import { AnyObject, TypeGuard } from './utils/type-util';
 
+/** JSON formats supported by the V2 client API. */
+export type JsonFormat = 'json' | 'json-v2';
+
+/** Message formats supported by the V2 client API. */
+export type Format = 'xml' | JsonFormat;
+
 /**
  * Basic client API to interact with a model server that conforms to the Modelserver API Version 2.
  */
@@ -29,42 +35,37 @@ export interface ModelServerClientApiV2 {
      * Any requests to the model server before the client has been initialized are expected to fail (i.e. throw an error)
      * @param baseUrl Url pointing to the API entry point
      * @param defaultFormat Optional fallback format that should used when a request method is invoked and no explicit format argument
-     *                      has been passed.
+     *                      has been passed. The default-default is `'json'`
      */
-    initialize(baseUrl: string, defaultFormat?: string): void | Promise<void>;
+    initialize(baseUrl: string, defaultFormat?: Format): void | Promise<void>;
 
     /**
      * Retrieves all available models of the current workspace.
-     * @param format
      */
     getAll(): Promise<Model[]>;
-    /**
-     * 3
-     * @param format
-     */
     getAll<M>(typeGuard: TypeGuard<M>): Promise<Model<M>[]>;
-    getAll(format: string): Promise<Model<string>[]>;
+    getAll(format: Format): Promise<Model<string>[]>;
 
-    get(modeluri: string, format?: string): Promise<AnyObject>;
-    get<M>(modeluri: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    get(modeluri: string, format?: Format): Promise<AnyObject>;
+    get<M>(modeluri: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
     getModelUris(): Promise<string[]>;
 
-    getElementById(modeluri: string, elementid: string, format?: string): Promise<AnyObject>;
-    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    getElementById(modeluri: string, elementid: string, format?: Format): Promise<AnyObject>;
+    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    getElementByName(modeluri: string, elementname: string, format?: string): Promise<AnyObject>;
-    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    getElementByName(modeluri: string, elementname: string, format?: Format): Promise<AnyObject>;
+    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
     delete(modeluri: string): Promise<boolean>;
 
     close(modeluri: string): Promise<boolean>;
 
-    create(modeluri: string, model: AnyObject | string, format?: string): Promise<AnyObject>;
-    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    create(modeluri: string, model: AnyObject | string, format?: Format): Promise<AnyObject>;
+    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    update(modeluri: string, model: AnyObject | string, format?: string): Promise<AnyObject>;
-    update<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    update(modeluri: string, model: AnyObject | string, format?: Format): Promise<AnyObject>;
+    update<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
     save(modeluri: string): Promise<boolean>;
 
@@ -82,8 +83,8 @@ export interface ModelServerClientApiV2 {
 
     ping(): Promise<boolean>;
 
-    edit(modeluri: string, patch: Operation | Operation[], format?: string): Promise<boolean>;
-    edit(modeluri: string, command: ModelServerCommand, format?: string): Promise<boolean>;
+    edit(modeluri: string, patch: Operation | Operation[], format?: Format): Promise<boolean>;
+    edit(modeluri: string, command: ModelServerCommand, format?: Format): Promise<boolean>;
 
     undo(modeluri: string): Promise<string>;
 

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -106,10 +106,12 @@ export namespace ModelServerClientApiV2 {
  * Result sent to client after requesting a model update.
  */
 export interface ModelUpdateResult {
+
     /**
      * True if the edit request was successful, false otherwise.
      */
     success: boolean;
+
     /**
      * A function to update the model. Only present if the edit request was successful.
      * The function can be applied to the original model (before edition) and will return
@@ -119,6 +121,13 @@ export interface ModelUpdateResult {
      * @param copy by default, the patch will be directly applied to the oldModel, modifying
      * it in-place. If copy is true, the patch will be applied on a copy of the model, leaving
      * the original model unchanged.
+     * @return the patched model.
      */
-    patch?(oldModel: ModelServerElement, copy?: boolean): ModelServerElement;
+    patchModel?(oldModel: ModelServerElement, copy?: boolean): ModelServerElement;
+
+    /**
+     * The Json Patch describing the changes that were applied to the model. Only present if
+     * the edit request was successful.
+     */
+    patch?: Operation[];
 }

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -18,11 +18,26 @@ import { Diagnostic } from './model/diagnostic';
 import { SubscriptionListener } from './subscription-listener';
 import { AnyObject, TypeGuard } from './utils/type-util';
 
+/**
+ * Message Format for Json Models (V1).
+ */
+export const FORMAT_JSON_V1 = 'json';
+
+/**
+ * Message Format for Json Models (V2).
+ */
+export const FORMAT_JSON_V2 = 'json-v2';
+
+/**
+ * Message Format for XMI Models.
+ */
+export const FORMAT_XMI = 'xmi';
+
 /** JSON formats supported by the V2 client API. */
 export type JsonFormat = 'json' | 'json-v2';
 
 /** Message formats supported by the V2 client API. */
-export type Format = 'xml' | JsonFormat;
+export type Format = string;
 
 /**
  * Basic client API to interact with a model server that conforms to the Modelserver API Version 2.
@@ -36,7 +51,7 @@ export interface ModelServerClientApiV2 {
      * Any requests to the model server before the client has been initialized are expected to fail (i.e. throw an error)
      * @param baseUrl Url pointing to the API entry point
      * @param defaultFormat Optional fallback format that should used when a request method is invoked and no explicit format argument
-     *                      has been passed. The default-default is `'json'`
+     *                      has been passed. The default-default is `'json-v2'`
      */
     initialize(baseUrl: string, defaultFormat?: Format): void | Promise<void>;
 

--- a/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
@@ -88,19 +88,19 @@ describe('Integration tests for ModelServerClientV2', () => {
             const initialModel = await client.get(modeluri, ModelServerObjectV2.is);
 
             // Add a second workflow to the model; we'll use it to move a Task from a workflow to the other
-            const createWorkflow = create(modeluri, initialModel, 'workflows', 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow', {name: "New Workflow"});
+            const createWorkflow = create(modeluri, initialModel, 'workflows', 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow', {name: 'New Workflow'});
             await client.edit(modeluri, createWorkflow);
             const originalModel = await client.get(modeluri, ModelServerObjectV2.is);
             const sourceWF = (originalModel as any).workflows[0];
             const targetWF = (originalModel as any).workflows[1];
 
-            const patch = add(modeluri, targetWF, "nodes", sourceWF.nodes[0]);
+            const patch = add(modeluri, targetWF, 'nodes', sourceWF.nodes[0]);
             await client.edit(modeluri, patch);
             const patchedModel = await client.get(modeluri);
-            
+
             const patchedSourceWF = (patchedModel as any).workflows[0];
             const patchedTargetWF = (patchedModel as any).workflows[1];
-            
+
             expect(patchedSourceWF.nodes).to.be.undefined;
             expect(patchedTargetWF.nodes).to.be.an('array').of.length(1);
             expect(patchedTargetWF.nodes[0].name).to.be.equal(sourceWF.nodes[0].name); // Node was moved

--- a/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
@@ -46,7 +46,7 @@ describe('Integration tests for ModelServerClientV2', () => {
 
     beforeEach(() => {
         client = new ModelServerClientV2();
-        client.initialize(baseUrl);
+        client.initialize(baseUrl, 'json-v2');
     });
 
     describe('test requests', () => {

--- a/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
@@ -1,0 +1,126 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+import { expect } from 'chai';
+
+import {
+    IncrementalUpdateNotificationV2,
+    ModelServerClientV2,
+    ModelServerNotification,
+    ModelServerNotificationListenerV2,
+    ModelServerObjectV2,
+    NotificationSubscriptionListenerV2,
+    Operations,
+    replace,
+    SetCommand
+} from '.';
+import { ModelServerClientApiV2 } from './model-server-client-api-v2';
+
+describe('Integration tests for ModelServerClientV2', () => {
+    let client: ModelServerClientV2;
+    const baseUrl = `http://localhost:8081${ModelServerClientApiV2.API_ENDPOINT}`;
+
+    beforeEach(() => {
+        client = new ModelServerClientV2();
+        client.initialize(baseUrl);
+    });
+
+    describe('test requests', () => {
+        it('edit with patch', async () => {
+            const modeluri = 'SuperBrewer3000.coffee';
+            const newName = 'Super Brewer 6000';
+            const machine = await client.get(modeluri, ModelServerObjectV2.is);
+            const originalName = (machine as any).name;
+            const patch = replace(modeluri, machine, 'name', newName);
+            await client.edit(modeluri, patch);
+            const model = await client.get(modeluri);
+            expect(model.name).to.be.equal(newName);
+
+            await client.undo(modeluri);
+            const resetModel = await client.get(modeluri);
+            expect(resetModel.name).to.be.equal(originalName);
+
+            await client.redo(modeluri);
+            const redoModel = await client.get(modeluri);
+            expect(redoModel.name).to.be.equal(newName);
+
+            // Restore initial state
+            await client.undo(modeluri);
+        });
+
+        it('edit with command', async () => {
+            const modeluri = 'SuperBrewer3000.coffee';
+            const newName = 'Super Brewer 6000';
+            const machine = await client.get(modeluri, ModelServerObjectV2.is);
+            const originalName = (machine as any).name;
+            const owner = {
+                eClass: machine.$type,
+                $ref: `SuperBrewer3000.coffee#${machine.$id}`
+            };
+            const command = new SetCommand(owner, 'name', [newName]);
+            await client.edit(modeluri, command);
+            const model = await client.get(modeluri);
+            expect(model.name).to.be.equal(newName);
+
+            await client.undo(modeluri);
+            const resetModel = await client.get(modeluri);
+            expect(resetModel.name).to.be.equal(originalName);
+
+            await client.redo(modeluri);
+            const redoModel = await client.get(modeluri);
+            expect(redoModel.name).to.be.equal(newName);
+
+            // Restore initial state
+            await client.undo(modeluri);
+        });
+
+        it('subscribe to changes', async () => {
+            const modeluri = 'SuperBrewer3000.coffee';
+            const newName = 'Super Brewer 6000';
+            const machine = await client.get(modeluri, ModelServerObjectV2.is);
+            const owner = {
+                eClass: machine.$type,
+                $ref: `SuperBrewer3000.coffee#${machine.$id}`
+            };
+            const command = new SetCommand(owner, 'name', [newName]);
+
+            const listener: ModelServerNotificationListenerV2 = {};
+
+            const patchNotification: Promise<IncrementalUpdateNotificationV2> = new Promise((resolve, _rej) => {
+                listener.onIncrementalUpdateV2 = resolve;
+            });
+
+            const subscription: Promise<ModelServerNotification> = new Promise((resolve, _rej) => {
+                listener.onSuccess = resolve;
+            });
+
+            client.subscribe(modeluri, new NotificationSubscriptionListenerV2(listener));
+            // Make sure the subscription is initialized before editing the model,
+            // so that we don't miss the notification
+            await subscription;
+
+            await client.edit(modeluri, command);
+            const notification = await patchNotification;
+            const patch = notification.patch;
+
+            expect(notification.modelUri).to.be.equal(modeluri);
+            expect(patch.length).to.be.equal(1);
+            const operation = patch[0];
+            expect(Operations.isReplace(operation, 'string')).to.be.equal(true);
+            expect(operation.path).to.be.equal('/name');
+            if (Operations.isReplace(operation, 'string')) {
+                expect(operation.value).to.be.equal(newName);
+            }
+
+            await client.undo(modeluri);
+            client.unsubscribe(modeluri);
+        });
+    });
+});

--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -15,7 +15,7 @@ import moxios from 'moxios';
 import { spy } from 'sinon';
 
 import { ServerConfiguration } from './model-server-client-api-v1';
-import { ModelServerClientApiV2 } from './model-server-client-api-v2';
+import { FORMAT_JSON_V2, FORMAT_XMI, ModelServerClientApiV2 } from './model-server-client-api-v2';
 import { ModelServerClientV2 } from './model-server-client-v2';
 import { Model, ModelServerMessage } from './model-server-message';
 import { ModelServerPaths } from './model-server-paths';
@@ -42,16 +42,16 @@ describe('tests for ModelServerClientV2', () => {
     describe('test requests', () => {
         it('getAll', done => {
             client.getAll();
-            client.getAll('xml');
+            client.getAll(FORMAT_XMI);
             client.getAll();
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
-                expect(request.config.params).to.include({ format: 'json' });
+                expect(request.config.params).to.include({ format: FORMAT_JSON_V2 });
                 expect(request.config.baseURL).to.be.equal(baseUrl);
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
-                expect(request.config.params).to.include({ format: 'xml' });
+                expect(request.config.params).to.include({ format: FORMAT_XMI });
                 done();
             });
         });
@@ -73,16 +73,16 @@ describe('tests for ModelServerClientV2', () => {
             const elementid = 'myElement';
 
             client.getElementById(modeluri, elementid);
-            client.getElementById(modeluri, elementid, 'xml');
+            client.getElementById(modeluri, elementid, FORMAT_XMI);
 
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
-                expect(request.config.params).to.include({ format: 'json', elementid, modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_JSON_V2, elementid, modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
-                expect(request.config.params).to.include({ format: 'xml', elementid, modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_XMI, elementid, modeluri });
                 done();
             });
         });
@@ -92,16 +92,16 @@ describe('tests for ModelServerClientV2', () => {
             const elementname = 'myElement';
 
             client.getElementByName(modeluri, elementname);
-            client.getElementByName(modeluri, elementname, 'xml');
+            client.getElementByName(modeluri, elementname, FORMAT_XMI);
 
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
-                expect(request.config.params).to.include({ format: 'json', elementname, modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_JSON_V2, elementname, modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
-                expect(request.config.params).to.include({ format: 'xml', elementname, modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_XMI, elementname, modeluri });
                 done();
             });
         });
@@ -137,17 +137,17 @@ describe('tests for ModelServerClientV2', () => {
             const model = { name: 'myModel', id: 'myModelId' };
             const data = JSON.stringify(model);
             client.create(modeluri, data);
-            client.create(modeluri, data, 'xml');
+            client.create(modeluri, data, FORMAT_XMI);
 
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
-                expect(request.config.params).to.include({ format: 'json', modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
-                expect(request.config.params).to.include({ format: 'xml', modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_XMI, modeluri });
                 done();
             });
         });
@@ -157,17 +157,17 @@ describe('tests for ModelServerClientV2', () => {
             const model = { name: 'myModel', id: 'myModelId' };
             const data = JSON.stringify(model);
             client.update(modeluri, data);
-            client.update(modeluri, data, 'xml');
+            client.update(modeluri, data, FORMAT_XMI);
 
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
-                expect(request.config.params).to.include({ format: 'json', modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
-                expect(request.config.params).to.include({ format: 'xml', modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_XMI, modeluri });
                 done();
             });
         });
@@ -297,7 +297,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data: expected }));
-                expect(request.config.params).to.include({ format: 'json', modeluri });
+                expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();

--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -1,0 +1,387 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+import { strictEqual } from 'assert';
+import { expect } from 'chai';
+import { Operation } from 'fast-json-patch';
+import moxios from 'moxios';
+import { spy } from 'sinon';
+
+import { ServerConfiguration } from './model-server-client-api-v1';
+import { ModelServerClientApiV2 } from './model-server-client-api-v2';
+import { ModelServerClientV2 } from './model-server-client-v2';
+import { Model, ModelServerMessage } from './model-server-message';
+import { ModelServerPaths } from './model-server-paths';
+
+describe('tests for ModelServerClientV2', () => {
+    let client: ModelServerClientV2;
+    const baseUrl = `http://localhost:8081${ModelServerClientApiV2.API_ENDPOINT}`;
+
+    beforeEach(() => {
+        client = new ModelServerClientV2();
+        client.initialize(baseUrl);
+        moxios.install(client['restClient']);
+    });
+
+    afterEach(() => {
+        moxios.uninstall(client['restClient']);
+    });
+
+    it('initialize - correct baseUrl config of axios instance', () => {
+        const axios = client['restClient'];
+        expect(axios.defaults.baseURL).to.be.equal(baseUrl);
+    });
+
+    describe('test requests', () => {
+        it('getAll', done => {
+            client.getAll();
+            client.getAll('xml');
+            client.getAll();
+            moxios.wait(() => {
+                let request = moxios.requests.at(0);
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ format: 'json' });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
+                request = moxios.requests.at(1);
+                expect(request.config.params).to.include({ format: 'xml' });
+                done();
+            });
+        });
+
+        it('getModelUris', done => {
+            client.getModelUris();
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.be.undefined;
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_URIS);
+                done();
+            });
+        });
+
+        it('getElementById', done => {
+            const modeluri = 'my/uri.model';
+            const elementid = 'myElement';
+
+            client.getElementById(modeluri, elementid);
+            client.getElementById(modeluri, elementid, 'xml');
+
+            moxios.wait(() => {
+                let request = moxios.requests.at(0);
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ format: 'json', elementid, modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
+                request = moxios.requests.at(1);
+                expect(request.config.params).to.include({ format: 'xml', elementid, modeluri });
+                done();
+            });
+        });
+
+        it('getElementByName', done => {
+            const modeluri = 'my/uri.model';
+            const elementname = 'myElement';
+
+            client.getElementByName(modeluri, elementname);
+            client.getElementByName(modeluri, elementname, 'xml');
+
+            moxios.wait(() => {
+                let request = moxios.requests.at(0);
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ format: 'json', elementname, modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
+                request = moxios.requests.at(1);
+                expect(request.config.params).to.include({ format: 'xml', elementname, modeluri });
+                done();
+            });
+        });
+
+        it('delete', done => {
+            const modeluri = 'delete/me/please';
+            client.delete(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('delete');
+                expect(request.config.params).to.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
+                done();
+            });
+        });
+
+        it('close', done => {
+            const modeluri = 'delete/me/please';
+            client.close(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('post');
+                expect(request.config.params).to.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.CLOSE);
+                done();
+            });
+        });
+
+        it('create', done => {
+            const modeluri = 'delete/me/please';
+            const model = { name: 'myModel', id: 'myModelId' };
+            const data = JSON.stringify(model);
+            client.create(modeluri, data);
+            client.create(modeluri, data, 'xml');
+
+            moxios.wait(() => {
+                let request = moxios.requests.at(0);
+                expect(request.config.method).to.be.equal('post');
+                expect(request.config.data).to.be.equal(JSON.stringify({ data }));
+                expect(request.config.params).to.include({ format: 'json', modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
+                request = moxios.requests.at(1);
+                expect(request.config.params).to.include({ format: 'xml', modeluri });
+                done();
+            });
+        });
+
+        it('update', done => {
+            const modeluri = 'delete/me/please';
+            const model = { name: 'myModel', id: 'myModelId' };
+            const data = JSON.stringify(model);
+            client.update(modeluri, data);
+            client.update(modeluri, data, 'xml');
+
+            moxios.wait(() => {
+                let request = moxios.requests.at(0);
+                expect(request.config.method).to.be.equal('patch');
+                expect(request.config.data).to.be.equal(JSON.stringify({ data }));
+                expect(request.config.params).to.include({ format: 'json', modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
+                request = moxios.requests.at(1);
+                expect(request.config.params).to.include({ format: 'xml', modeluri });
+                done();
+            });
+        });
+
+        it('save', done => {
+            const modeluri = 'save/me/please';
+            client.save(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.SAVE);
+                done();
+            });
+        });
+
+        it('save', done => {
+            client.saveAll();
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.be.undefined;
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.SAVE_ALL);
+                done();
+            });
+        });
+
+        it('validate', done => {
+            const modeluri = 'validate/me/please';
+            client.validate(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION);
+                done();
+            });
+        });
+
+        it('getValidationConstraints', done => {
+            const modeluri = 'validate/me/please';
+            client.getValidationConstraints(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION_CONSTRAINTS);
+                done();
+            });
+        });
+
+        it('getTypeSchema', done => {
+            const modeluri = 'my/model/uri';
+            client.getTypeSchema(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.TYPE_SCHEMA);
+                done();
+            });
+        });
+
+        it('getUiSchema', done => {
+            const schemaname = 'myschema';
+            client.getUiSchema(schemaname);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.include({ schemaname });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.UI_SCHEMA);
+                done();
+            });
+        });
+
+        it('configureServer', done => {
+            const configuration: ServerConfiguration = {
+                workspaceRoot: 'myRoot',
+                uiSchemaFolder: 'mySchemaFolder'
+            };
+            client.configureServer(configuration);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('put');
+                expect(request.config.data).to.equal(JSON.stringify(configuration));
+                expect(request.config.params).to.be.undefined;
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);
+                done();
+            });
+        });
+
+        it('ping', done => {
+            client.ping();
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.be.undefined;
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_PING);
+                done();
+            });
+        });
+
+        it('edit', done => {
+            const modeluri = 'edit/me/please';
+            const patch: Operation[] = [
+                {
+                    op: 'replace',
+                    path: 'SuperBrewer3000.coffee#//@workflows.0/name',
+                    value: 'Auto Brew Workflow'
+                }
+            ];
+            const expected = {
+                type: 'modelserver.patch',
+                data: patch
+            };
+            client.edit(modeluri, patch);
+
+            moxios.wait(() => {
+                const request = moxios.requests.at(0);
+                expect(request.config.method).to.be.equal('patch');
+                expect(request.config.data).to.be.equal(JSON.stringify({ data: expected }));
+                expect(request.config.params).to.include({ format: 'json', modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
+                done();
+            });
+        });
+
+        it('undo', done => {
+            const modeluri = 'undo/me/please';
+            client.undo(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.be.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.UNDO);
+                done();
+            });
+        });
+
+        it('redo', done => {
+            const modeluri = 'redo/me/please';
+            client.redo(modeluri);
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                expect(request.config.method).to.be.equal('get');
+                expect(request.config.params).to.be.include({ modeluri });
+                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.url).to.be.equal(ModelServerPaths.REDO);
+                done();
+            });
+        });
+    });
+
+    describe('test responses', () => {
+        it('ping ', done => {
+            const expectedMsg: ModelServerMessage = {
+                data: '',
+                type: 'success'
+            };
+            const onFulfilled = spy();
+            client.ping().then(onFulfilled);
+            moxios.wait(async () => {
+                const request = moxios.requests.mostRecent();
+                await request.respondWith({
+                    status: 200,
+                    response: expectedMsg
+                });
+                strictEqual(onFulfilled.getCall(0).args[0], true);
+                done();
+            });
+        });
+
+        it('ping ', done => {
+            const model1: Model = {
+                modelUri: 'path/to/model1',
+                content: {
+                    name: 'coffee'
+                }
+            };
+            const model2: Model = {
+                modelUri: 'path/to/model2',
+                content: {
+                    name: 'coffee'
+                }
+            };
+            const response: ModelServerMessage = {
+                data: {
+                    [model1.modelUri]: model1.content,
+                    [model2.modelUri]: model2.content
+                },
+                type: 'success'
+            };
+            const onFulfilled = spy();
+            client.getAll().then(onFulfilled);
+            moxios.wait(async () => {
+                const request = moxios.requests.mostRecent();
+                await request.respondWith({
+                    status: 200,
+                    response
+                });
+                const result = onFulfilled.getCall(0).args[0];
+                expect(result).to.deep.include.members([model2, model1]);
+                done();
+            });
+        });
+    });
+});

--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -161,7 +161,7 @@ describe('tests for ModelServerClientV2', () => {
 
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
-                expect(request.config.method).to.be.equal('patch');
+                expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -13,7 +13,7 @@ import { Operation } from 'fast-json-patch';
 import WebSocket from 'isomorphic-ws';
 
 import { ModelServerError, ServerConfiguration, SubscriptionOptions } from './model-server-client-api-v1';
-import { Format, ModelServerClientApiV2, ModelUpdateResult } from './model-server-client-api-v2';
+import { Format, FORMAT_JSON_V2, ModelServerClientApiV2, ModelUpdateResult } from './model-server-client-api-v2';
 import { MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
 import { ModelServerPaths } from './model-server-paths';
 import { ModelServerCommand } from './model/command-model';
@@ -28,9 +28,9 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
     protected restClient: AxiosInstance;
     protected openSockets: Map<string, WebSocket> = new Map();
     protected _baseUrl: string;
-    protected defaultFormat: Format = 'json';
+    protected defaultFormat: Format = FORMAT_JSON_V2;
 
-    initialize(baseUrl: string, defaultFormat: Format = 'json'): void | Promise<void> {
+    initialize(baseUrl: string, defaultFormat: Format = FORMAT_JSON_V2): void | Promise<void> {
         this._baseUrl = baseUrl;
         this.defaultFormat = defaultFormat;
         this.restClient = axios.create(this.getAxiosConfig(baseUrl));

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -239,12 +239,12 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
         );
     }
 
-    undo(modeluri: string): Promise<string> {
-        return this.process(this.restClient.get(ModelServerPaths.UNDO, { params: { modeluri } }), MessageDataMapper.asString);
+    undo(modeluri: string): Promise<ModelUpdateResult> {
+        return this.process(this.restClient.get(ModelServerPaths.UNDO, { params: { modeluri } }), MessageDataMapper.patchModel);
     }
 
-    redo(modeluri: string): Promise<string> {
-        return this.process(this.restClient.get(ModelServerPaths.REDO, { params: { modeluri } }), MessageDataMapper.asString);
+    redo(modeluri: string): Promise<ModelUpdateResult> {
+        return this.process(this.restClient.get(ModelServerPaths.REDO, { params: { modeluri } }), MessageDataMapper.patchModel);
     }
 
     send(modelUri: string, message: ModelServerMessage): void {

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -1,0 +1,337 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { Operation } from 'fast-json-patch';
+import WebSocket from 'isomorphic-ws';
+
+import { ModelServerError, ServerConfiguration, SubscriptionOptions } from './model-server-client-api-v1';
+import { ModelServerClientApiV2 } from './model-server-client-api-v2';
+import { MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
+import { ModelServerPaths } from './model-server-paths';
+import { ModelServerCommand } from './model/command-model';
+import { Diagnostic } from './model/diagnostic';
+import { SubscriptionListener } from './subscription-listener';
+import { AnyObject, asObject, asString, asType, TypeGuard } from './utils/type-util';
+
+/**
+ * A client to interact with a model server.
+ */
+export class ModelServerClientV2 implements ModelServerClientApiV2 {
+    protected restClient: AxiosInstance;
+    protected openSockets: Map<string, WebSocket> = new Map();
+    protected _baseUrl: string;
+    protected defaultFormat = 'json';
+
+    initialize(baseUrl: string): void | Promise<void> {
+        this._baseUrl = baseUrl;
+        this.restClient = axios.create(this.getAxiosConfig(baseUrl));
+    }
+
+    protected getAxiosConfig(baseURL: string): AxiosRequestConfig | undefined {
+        return { baseURL };
+    }
+
+    get(modeluri: string, format?: string): Promise<AnyObject>;
+    get<M>(modeluri: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    get<M>(modeluri: string, formatOrGuard?: FormatOrGuard<M>, format?: string): Promise<AnyObject | M> {
+        if (typeof formatOrGuard === 'function') {
+            const typeGuard = formatOrGuard;
+            return this.process(this.restClient.get(ModelServerPaths.MODEL_CRUD, { params: { modeluri, format } }), msg =>
+                MessageDataMapper.as(msg, typeGuard)
+            );
+        }
+        format = formatOrGuard;
+        return this.process(this.restClient.get(ModelServerPaths.MODEL_CRUD, { params: { modeluri, format } }), MessageDataMapper.asObject);
+    }
+
+    getAll(): Promise<Model[]>;
+    getAll<M>(typeGuard: TypeGuard<M>): Promise<Model<M>[]>;
+    getAll(format: string): Promise<Model<string>[]>;
+    getAll<M>(formatOrGuard?: FormatOrGuard<M>): Promise<Array<Model | Model<string> | Model<M>>> {
+        let modelMapper: (model: Model) => Model<string | AnyObject | M>;
+        let format = 'json';
+        if (!formatOrGuard) {
+            modelMapper = (model: Model) => mapModel(model);
+        } else if (typeof formatOrGuard === 'string') {
+            format = formatOrGuard;
+            modelMapper = (model: Model) => mapModel(model, undefined, true);
+        } else {
+            modelMapper = (model: Model) => mapModel(model, formatOrGuard);
+        }
+        const messageMapper = (message: ModelServerMessage): Array<Model | Model<string> | Model<M>> =>
+            MessageDataMapper.asModelArray(message).map(modelMapper);
+
+        return this.process(this.restClient.get(ModelServerPaths.MODEL_CRUD, { params: { format } }), messageMapper);
+    }
+
+    getModelUris(): Promise<string[]> {
+        return this.process(this.restClient.get(ModelServerPaths.MODEL_URIS), MessageDataMapper.asStringArray);
+    }
+
+    getElementById(modeluri: string, elementid: string, format?: string): Promise<AnyObject>;
+    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>): Promise<M>;
+    getElementById<M>(modeluri: string, elementid: string, formatOrGuard?: FormatOrGuard<M>, format?: string): Promise<AnyObject | M> {
+        format = format ?? 'json';
+        if (formatOrGuard) {
+            if (typeof formatOrGuard === 'function') {
+                const typeGuard = formatOrGuard;
+                return this.process(this.restClient.get(ModelServerPaths.MODEL_ELEMENT, { params: { modeluri, elementid, format } }), msg =>
+                    MessageDataMapper.as(msg, typeGuard)
+                );
+            }
+            format = formatOrGuard;
+        }
+        return this.process(
+            this.restClient.get(ModelServerPaths.MODEL_ELEMENT, { params: { modeluri, elementid, format } }),
+            MessageDataMapper.asObject
+        );
+    }
+
+    getElementByName(modeluri: string, elementname: string, format?: string): Promise<AnyObject>;
+    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    getElementByName<M>(modeluri: string, elementname: string, formatOrGuard?: FormatOrGuard<M>, format?: string): Promise<AnyObject | M> {
+        format = format ?? 'json';
+        if (formatOrGuard) {
+            if (typeof formatOrGuard === 'function') {
+                const typeGuard = formatOrGuard;
+                return this.process(
+                    this.restClient.get(ModelServerPaths.MODEL_ELEMENT, { params: { modeluri, elementname, format } }),
+                    msg => MessageDataMapper.as(msg, typeGuard)
+                );
+            }
+            format = formatOrGuard;
+        }
+        return this.process(
+            this.restClient.get(ModelServerPaths.MODEL_ELEMENT, { params: { modeluri, elementname, format } }),
+            MessageDataMapper.asObject
+        );
+    }
+
+    create(modeluri: string, model: AnyObject | string, format?: string): Promise<AnyObject>;
+    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    create<M>(modeluri: string, model: AnyObject | string, formatOrGuard?: FormatOrGuard<M>, format?: string): Promise<AnyObject | M> {
+        format = format ?? 'json';
+        if (formatOrGuard) {
+            if (typeof formatOrGuard === 'function') {
+                const typeGuard = formatOrGuard;
+                return this.process(
+                    this.restClient.post(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+                    msg => MessageDataMapper.as(msg, typeGuard)
+                );
+            }
+            format = formatOrGuard;
+        }
+        return this.process(
+            this.restClient.post(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+            MessageDataMapper.asObject
+        );
+    }
+
+    update(modeluri: string, model: AnyObject | string, format?: string): Promise<AnyObject>;
+    update<M>(modeluri: string, model: string | string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    update<M>(
+        modeluri: string,
+        model: AnyObject | string,
+        formatOrGuard?: FormatOrGuard<M>,
+        format?: string
+    ): Promise<AnyObject> | Promise<M> {
+        format = format ?? 'json';
+        if (formatOrGuard) {
+            if (typeof formatOrGuard === 'function') {
+                const typeGuard = formatOrGuard;
+                return this.process(
+                    this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+                    msg => MessageDataMapper.as(msg, typeGuard)
+                );
+            }
+            format = formatOrGuard;
+        }
+        return this.process(
+            this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+            MessageDataMapper.asObject
+        );
+    }
+
+    delete(modeluri: string): Promise<boolean> {
+        return this.process(this.restClient.delete(ModelServerPaths.MODEL_CRUD, { params: { modeluri } }), MessageDataMapper.isSuccess);
+    }
+
+    close(modeluri: string): Promise<boolean> {
+        return this.process(this.restClient.post(ModelServerPaths.CLOSE, undefined, { params: { modeluri } }), MessageDataMapper.isSuccess);
+    }
+
+    save(modeluri: string): Promise<boolean> {
+        return this.process(this.restClient.get(ModelServerPaths.SAVE, { params: { modeluri } }), MessageDataMapper.isSuccess);
+    }
+
+    saveAll(): Promise<boolean> {
+        return this.process(this.restClient.get(ModelServerPaths.SAVE_ALL), MessageDataMapper.isSuccess);
+    }
+
+    validate(modeluri: string): Promise<Diagnostic> {
+        return this.process(this.restClient.get(ModelServerPaths.VALIDATION, { params: { modeluri } }), response =>
+            MessageDataMapper.as(response, Diagnostic.is)
+        );
+    }
+
+    getValidationConstraints(modeluri: string): Promise<string> {
+        return this.process(
+            this.restClient.get(ModelServerPaths.VALIDATION_CONSTRAINTS, { params: { modeluri } }),
+            MessageDataMapper.asString
+        );
+    }
+
+    getTypeSchema(modeluri: string): Promise<string> {
+        return this.process(this.restClient.get(ModelServerPaths.TYPE_SCHEMA, { params: { modeluri } }), MessageDataMapper.asString);
+    }
+
+    getUiSchema(schemaname: string): Promise<string> {
+        return this.process(this.restClient.get(ModelServerPaths.UI_SCHEMA, { params: { schemaname } }), MessageDataMapper.asString);
+    }
+
+    configureServer(configuration: ServerConfiguration): Promise<boolean> {
+        let { workspaceRoot, uiSchemaFolder } = configuration;
+        workspaceRoot = workspaceRoot.replace('file://', '');
+        uiSchemaFolder = uiSchemaFolder?.replace('file://', '');
+        return this.process(
+            this.restClient.put(ModelServerPaths.SERVER_CONFIGURE, { workspaceRoot, uiSchemaFolder }),
+            MessageDataMapper.isSuccess
+        );
+    }
+
+    ping(): Promise<boolean> {
+        return this.process(this.restClient.get(ModelServerPaths.SERVER_PING), MessageDataMapper.isSuccess);
+    }
+
+    edit(modeluri: string, patch: Operation): Promise<boolean>;
+    edit(modeluri: string, patch: Operation[]): Promise<boolean>;
+    edit(modeluri: string, command: ModelServerCommand): Promise<boolean>;
+    edit(modeluri: string, patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<boolean> {
+        let patchMessage: any;
+        if (patchOrCommand instanceof ModelServerCommand) {
+            patchMessage = {
+                type: 'modelserver.emfcommand',
+                data: patchOrCommand
+            };
+        } else {
+            const fullPatch = Array.isArray(patchOrCommand) ? patchOrCommand : [patchOrCommand];
+            patchMessage = {
+                type: 'modelserver.patch',
+                data: fullPatch
+            };
+        }
+        return this.process(
+            this.restClient.patch(
+                ModelServerPaths.MODEL_CRUD,
+                { data: patchMessage },
+                { params: { modeluri, format: this.defaultFormat } }
+            ),
+            MessageDataMapper.isSuccess
+        );
+    }
+
+    undo(modeluri: string): Promise<string> {
+        return this.process(this.restClient.get(ModelServerPaths.UNDO, { params: { modeluri } }), MessageDataMapper.asString);
+    }
+
+    redo(modeluri: string): Promise<string> {
+        return this.process(this.restClient.get(ModelServerPaths.REDO, { params: { modeluri } }), MessageDataMapper.asString);
+    }
+
+    send(modelUri: string, message: ModelServerMessage): void {
+        const openSocket = this.openSockets.get(modelUri);
+        if (openSocket) {
+            openSocket.send(message);
+        }
+    }
+
+    subscribe(modeluri: string, listener: SubscriptionListener, options: SubscriptionOptions = {}): SubscriptionListener {
+        if (this.isSocketOpen(modeluri)) {
+            const errorMsg = `${modeluri} : Cannot open new socket, already subscribed!'`;
+            console.warn(errorMsg);
+            if (options.errorWhenUnsuccessful) {
+                throw new Error('errorMsg');
+            }
+        }
+        const path = this.createSubscriptionPath(modeluri, options);
+        this.doSubscribe(listener, modeluri, path);
+        return listener;
+    }
+
+    unsubscribe(modeluri: string): void {
+        const openSocket = this.openSockets.get(modeluri);
+        if (openSocket) {
+            openSocket.close();
+            this.openSockets.delete(modeluri);
+        }
+    }
+
+    protected createSubscriptionPath(modeluri: string, options: SubscriptionOptions): string {
+        const queryParams = new URLSearchParams();
+        queryParams.append('modeluri', modeluri);
+        if (!options.format) {
+            options.format = this.defaultFormat;
+        }
+        Object.entries(options).forEach(entry => queryParams.append(entry[0], entry[1]));
+        queryParams.delete('errorWhenUnsuccessful');
+        return `${this._baseUrl}/${ModelServerPaths.SUBSCRIPTION}?${queryParams.toString()}`.replace(/^(http|https):\/\//i, 'ws://');
+    }
+
+    protected doSubscribe(listener: SubscriptionListener, modelUri: string, path: string): void {
+        const socket = new WebSocket(path.trim());
+        socket.onopen = event => listener.onOpen?.(modelUri, event);
+        socket.onclose = event => listener.onClose?.(modelUri, event);
+        socket.onerror = event => listener.onError?.(modelUri, event);
+        socket.onmessage = event => listener.onMessage?.(modelUri, event);
+        this.openSockets.set(modelUri, socket);
+    }
+
+    protected isSocketOpen(modelUri: string): boolean {
+        return this.openSockets.get(modelUri) !== undefined;
+    }
+
+    protected async process<T>(request: Promise<AxiosResponse<ModelServerMessage>>, mapper: MessageDataMapper<T>): Promise<T> {
+        try {
+            const response = await request;
+            if (response.data.type === 'error') {
+                throw new ModelServerError(response.data);
+            }
+            return mapper(response.data);
+        } catch (error) {
+            if (isAxiosError(error)) {
+                const message = error.response?.data ? error.response.data : error.message;
+                throw new ModelServerError(message, error.code);
+            } else {
+                throw error;
+            }
+        }
+    }
+}
+
+function isAxiosError(error: any): error is AxiosError {
+    return error !== undefined && error instanceof Error && 'isAxiosError' in error && error['isAxiosError'];
+}
+
+/**
+ * Helper type for method overloads where on parameter could either be
+ * a 'format' string or a typeguard to cast the response to a concrete type.
+ */
+type FormatOrGuard<M> = string | TypeGuard<M>;
+
+function mapModel<M>(model: Model, guard?: TypeGuard<M>, toString = false): Model<AnyObject | M | string> {
+    const { modelUri, content } = model;
+    if (guard) {
+        return { modelUri, content: asType(content, guard) };
+    } else if (toString) {
+        return { modelUri, content: asString(content) };
+    }
+    return { modelUri, content: asObject(content) };
+}

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -13,7 +13,7 @@ import { Operation } from 'fast-json-patch';
 import WebSocket from 'isomorphic-ws';
 
 import { ModelServerError, ServerConfiguration, SubscriptionOptions } from './model-server-client-api-v1';
-import { Format, ModelServerClientApiV2 } from './model-server-client-api-v2';
+import { Format, ModelServerClientApiV2, ModelUpdateResult } from './model-server-client-api-v2';
 import { MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
 import { ModelServerPaths } from './model-server-paths';
 import { ModelServerCommand } from './model/command-model';
@@ -212,10 +212,10 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
         return this.process(this.restClient.get(ModelServerPaths.SERVER_PING), MessageDataMapper.isSuccess);
     }
 
-    edit(modeluri: string, patch: Operation): Promise<boolean>;
-    edit(modeluri: string, patch: Operation[]): Promise<boolean>;
-    edit(modeluri: string, command: ModelServerCommand): Promise<boolean>;
-    edit(modeluri: string, patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<boolean> {
+    edit(modeluri: string, patch: Operation): Promise<ModelUpdateResult>;
+    edit(modeluri: string, patch: Operation[]): Promise<ModelUpdateResult>;
+    edit(modeluri: string, command: ModelServerCommand): Promise<ModelUpdateResult>;
+    edit(modeluri: string, patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<ModelUpdateResult> {
         let patchMessage: any;
         if (patchOrCommand instanceof ModelServerCommand) {
             patchMessage = {
@@ -235,7 +235,7 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
                 encodeRequestBody(this.defaultFormat)(patchMessage),
                 { params: { modeluri, format: this.defaultFormat } }
             ),
-            MessageDataMapper.isSuccess
+            MessageDataMapper.patchModel
         );
     }
 

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -148,14 +148,14 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
             if (typeof formatOrGuard === 'function') {
                 const typeGuard = formatOrGuard;
                 return this.process(
-                    this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+                    this.restClient.put(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
                     msg => MessageDataMapper.as(msg, typeGuard)
                 );
             }
             format = formatOrGuard;
         }
         return this.process(
-            this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+            this.restClient.put(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
             MessageDataMapper.asObject
         );
     }

--- a/packages/modelserver-client/src/model-server-message.ts
+++ b/packages/modelserver-client/src/model-server-message.ts
@@ -8,6 +8,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
+import * as jsonpatch from 'fast-json-patch';
+
+import { ModelUpdateResult } from './model-server-client-api-v2';
+import { ModelServerElement } from './model/base-model';
+import { Operations } from './utils/patch-utils';
 import * as Type from './utils/type-util';
 
 /**
@@ -171,12 +176,38 @@ export namespace MessageDataMapper {
     }
 
     /**
-     * Maps the {@link ModelServerMessage.data} property of the given message to a `boolean` indicating wether the message
+     * Maps the {@link ModelServerMessage.data} property of the given message to a `boolean` indicating whether the message
      * has the {@link MessageType.success} type.
      * @param message The message to map.
      * @returns `true` if the type of the message is {@link MessageType.success}, `false` otherwise.
      */
     export function isSuccess(message: ModelServerMessage): boolean {
         return message.type === 'success';
+    }
+
+    /**
+     * Maps the {@link ModelServerMessage.data} property of the given message to a {@link ModelUpdateResult}, indicating
+     * if the edit operation was successful (success: true), and if it was, how to patch the original model
+     * to get the updated version of the model.
+     *
+     * @param message The message to map.
+     * @returns a {@link ModelUpdateResult} indicating if the operation was successful, and how to patch the local
+     * model to get the new model if it was.
+     */
+    export function patchModel(message: ModelServerMessage): ModelUpdateResult {
+        if (isSuccess(message)){
+            const data = message.data as any;
+            const patch = data ? data.patch : undefined;
+            if (patch && Operations.isPatch(patch)) {
+                return {
+                    success: isSuccess(message),
+                    patch: oldModel => jsonpatch.applyPatch(oldModel, patch).newDocument as ModelServerElement
+                };
+            } else {
+                return { success: true };
+            }
+        } else {
+            return {success: false };
+        }
     }
 }

--- a/packages/modelserver-client/src/model-server-message.ts
+++ b/packages/modelserver-client/src/model-server-message.ts
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import * as jsonpatch from 'fast-json-patch';
+import { deepClone } from 'fast-json-patch';
 
 import { ModelUpdateResult } from './model-server-client-api-v2';
 import { ModelServerElement } from './model/base-model';
@@ -201,7 +202,10 @@ export namespace MessageDataMapper {
             if (patch && Operations.isPatch(patch)) {
                 return {
                     success: isSuccess(message),
-                    patch: oldModel => jsonpatch.applyPatch(oldModel, patch).newDocument as ModelServerElement
+                    patch: (oldModel, copy) => {
+                        const modelToPatch = copy ? deepClone(oldModel) : oldModel;
+                        return jsonpatch.applyPatch(modelToPatch, patch).newDocument as ModelServerElement;
+                    }
                 };
             } else {
                 return { success: true };

--- a/packages/modelserver-client/src/model-server-message.ts
+++ b/packages/modelserver-client/src/model-server-message.ts
@@ -202,7 +202,8 @@ export namespace MessageDataMapper {
             if (patch && Operations.isPatch(patch)) {
                 return {
                     success: isSuccess(message),
-                    patch: (oldModel, copy) => {
+                    patch,
+                    patchModel: (oldModel, copy) => {
                         const modelToPatch = copy ? deepClone(oldModel) : oldModel;
                         return jsonpatch.applyPatch(modelToPatch, patch).newDocument as ModelServerElement;
                     }

--- a/packages/modelserver-client/src/model-server-notification.ts
+++ b/packages/modelserver-client/src/model-server-notification.ts
@@ -10,7 +10,7 @@
  *********************************************************************************/
 import { Operation } from 'fast-json-patch';
 
-import { MessageType } from '.';
+import { MessageType, ModelServerObjectV2 } from '.';
 import { ModelServerMessage } from './model-server-message';
 import { CommandExecutionResult } from './model/command-model';
 import { Diagnostic } from './model/diagnostic';
@@ -99,6 +99,16 @@ export namespace IncrementalUpdateNotification {
 export interface IncrementalUpdateNotificationV2 extends ModelServerNotification {
     /** The description of the incremental change */
     patch: Operation[];
+
+    /**
+     * A function to apply the patch on the previous version of the model.
+     * @param oldModel The model to patch.
+     * @param copy by default, the patch will be directly applied to the oldModel, modifying
+     * it in-place. If copy is true, the patch will be applied on a copy of the model, leaving
+     * the original model unchanged.
+     * @return the patched model.
+     */
+    patchModel(oldModel: ModelServerObjectV2, copy?: boolean): ModelServerObjectV2;
 }
 
 /**

--- a/packages/modelserver-client/src/model-server-notification.ts
+++ b/packages/modelserver-client/src/model-server-notification.ts
@@ -8,6 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *********************************************************************************/
+import { Operation } from 'fast-json-patch';
 import { MessageType } from '.';
 import { ModelServerMessage } from './model-server-message';
 import { CommandExecutionResult } from './model/command-model';
@@ -88,6 +89,24 @@ export namespace IncrementalUpdateNotification {
     export function is(object?: unknown): object is IncrementalUpdateNotification {
         return ModelServerNotification.is(object) && object.type === MessageType.incrementalUpdate;
     }
+}
+
+/**
+ * An `IncrementalUpdateNotification` is sent to notify subscribers about an incremental model change.
+ * The incremental change is described using JsonPatch {@link Operation}[]
+ */
+export interface IncrementalUpdateNotificationV2 extends ModelServerNotification {
+    /** The description of the incremental change */
+    patch: Operation[];
+}
+
+/**
+ * An `IncrementalUpdateNotification` is sent to notify subscribers about an incremental model change.
+ * The incremental change is described using JsonPatch {@link Operation}[]
+ */
+export interface IncrementalUpdateNotificationV2 extends ModelServerNotification {
+    /** The description of the incremental change */
+    patch: Operation[];
 }
 
 /**

--- a/packages/modelserver-client/src/model-server-notification.ts
+++ b/packages/modelserver-client/src/model-server-notification.ts
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *********************************************************************************/
 import { Operation } from 'fast-json-patch';
+
 import { MessageType } from '.';
 import { ModelServerMessage } from './model-server-message';
 import { CommandExecutionResult } from './model/command-model';
@@ -89,15 +90,6 @@ export namespace IncrementalUpdateNotification {
     export function is(object?: unknown): object is IncrementalUpdateNotification {
         return ModelServerNotification.is(object) && object.type === MessageType.incrementalUpdate;
     }
-}
-
-/**
- * An `IncrementalUpdateNotification` is sent to notify subscribers about an incremental model change.
- * The incremental change is described using JsonPatch {@link Operation}[]
- */
-export interface IncrementalUpdateNotificationV2 extends ModelServerNotification {
-    /** The description of the incremental change */
-    patch: Operation[];
 }
 
 /**

--- a/packages/modelserver-client/src/model/base-model.ts
+++ b/packages/modelserver-client/src/model/base-model.ts
@@ -25,3 +25,41 @@ export class ModelServerReferenceDescription extends ModelServerObject {
         super();
     }
 }
+
+/**
+ * A ModelServer model element. ModelServerElements may be actual objects,
+ * or references to an object defined in another part of the model, or even
+ * in a different model.
+ */
+export abstract class ModelServerElement {
+    readonly $type: string;
+
+    static is(object: unknown): object is ModelServerElement {
+        return AnyObject.is(object) && isString(object, '$type');
+    }
+}
+
+/**
+ * A ModelServer object.
+ */
+export class ModelServerObjectV2 extends ModelServerElement {
+    readonly $id: string;
+
+    static is(object: unknown): object is ModelServerObjectV2 {
+        return AnyObject.is(object) && isString(object, '$type') && isString(object, '$id');
+    }
+}
+
+/**
+ * A ModelServer Reference. References an object defined in another part of the model,
+ * or even in a different model.
+ */
+export class ModelServerReferenceDescriptionV2 extends ModelServerElement {
+    constructor(public $type: string, public $ref: string) {
+        super();
+    }
+
+    static is(object: unknown): object is ModelServerReferenceDescriptionV2 {
+        return AnyObject.is(object) && isString(object, '$type') && isString(object, '$ref');
+    }
+}

--- a/packages/modelserver-client/src/model/diagnostic.spec.ts
+++ b/packages/modelserver-client/src/model/diagnostic.spec.ts
@@ -1,0 +1,83 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+import { expect } from 'chai';
+import { Diagnostic, ERROR, OK, WARNING } from './diagnostic';
+
+describe('tests for Diagnostic', () => {
+
+    it('ok', () => {
+        const ok = Diagnostic.ok();
+
+        expect(ok.severity).to.be.equal(OK);
+        expect(ok.source).to.be.empty;
+        expect(ok.code).to.be.equal(0);
+        expect(ok.children).to.be.empty;
+        expect(ok.data).to.be.empty;
+        expect(ok.exception).to.be.undefined;
+        expect(ok.message).to.be.equal('OK');
+    });
+
+    describe('merge', () => {
+        it('no args', () => {
+            const merged = Diagnostic.merge();
+            expect(merged).to.be.eql(Diagnostic.ok());
+        });
+
+        it('one arg', () => {
+            const only = d(WARNING, 'This is a warning.');
+            const merged = Diagnostic.merge(only);
+            expect(merged).to.be.eql(only);
+        });
+
+        it('several args', () => {
+            const warning = { ...d(WARNING, 'Not so bad.'), source: 'a' };
+            const ok =  { ...d(OK, 'It\'s okay.'), source: 'b' };
+            const error =  { ...d(ERROR, 'Pretty bad.'), source: 'c' };
+            const merged = Diagnostic.merge(warning, ok, error);
+            expect(merged.severity).to.be.equal(ERROR);
+            expect(merged.source).to.be.equal('c');
+            expect(merged.children).to.be.eql([warning, error]);
+        });
+    });
+
+    describe('worstOf', () => {
+        it('no args', () => {
+            const worst = Diagnostic.worstOf([]);
+            expect(worst).to.be.eql(Diagnostic.ok());
+        });
+
+        it('one arg', () => {
+            const only = d(WARNING, 'This is a warning.');
+            const worst = Diagnostic.worstOf([only]);
+            expect(worst).to.be.equal(only);
+        });
+
+        it('several args', () => {
+            const warning = { ...d(WARNING, 'Not so bad.'), source: 'a' };
+            const ok =  { ...d(OK, 'It\'s okay.'), source: 'b' };
+            const error =  { ...d(ERROR, 'Pretty bad.'), source: 'c' };
+            const worst = Diagnostic.worstOf([warning, ok, error]);
+            expect(worst).to.be.equal(error);
+        });
+    });
+});
+
+function d(severity: number, message = 'A problem occurred.', ...children: Diagnostic[]): Diagnostic {
+    return {
+        severity,
+        message,
+        data: [],
+        children,
+        code: 0,
+        source: 'test',
+        id: ''
+    };
+}

--- a/packages/modelserver-client/src/model/diagnostic.spec.ts
+++ b/packages/modelserver-client/src/model/diagnostic.spec.ts
@@ -32,15 +32,15 @@ describe('tests for Diagnostic', () => {
         });
 
         it('one arg', () => {
-            const only = d(WARNING, 'This is a warning.');
+            const only = diag(WARNING, 'This is a warning.');
             const merged = Diagnostic.merge(only);
             expect(merged).to.be.eql(only);
         });
 
         it('several args', () => {
-            const warning = { ...d(WARNING, 'Not so bad.'), source: 'a' };
-            const ok =  { ...d(OK, 'It\'s okay.'), source: 'b' };
-            const error =  { ...d(ERROR, 'Pretty bad.'), source: 'c' };
+            const warning = { ...diag(WARNING, 'Not so bad.'), source: 'a' };
+            const ok = { ...diag(OK, 'It\'s okay.'), source: 'b' };
+            const error = { ...diag(ERROR, 'Pretty bad.'), source: 'c' };
             const merged = Diagnostic.merge(warning, ok, error);
             expect(merged.severity).to.be.equal(ERROR);
             expect(merged.source).to.be.equal('c');
@@ -55,22 +55,22 @@ describe('tests for Diagnostic', () => {
         });
 
         it('one arg', () => {
-            const only = d(WARNING, 'This is a warning.');
+            const only = diag(WARNING, 'This is a warning.');
             const worst = Diagnostic.worstOf([only]);
             expect(worst).to.be.equal(only);
         });
 
         it('several args', () => {
-            const warning = { ...d(WARNING, 'Not so bad.'), source: 'a' };
-            const ok =  { ...d(OK, 'It\'s okay.'), source: 'b' };
-            const error =  { ...d(ERROR, 'Pretty bad.'), source: 'c' };
+            const warning = { ...diag(WARNING, 'Not so bad.'), source: 'a' };
+            const ok = { ...diag(OK, 'It\'s okay.'), source: 'b' };
+            const error = { ...diag(ERROR, 'Pretty bad.'), source: 'c' };
             const worst = Diagnostic.worstOf([warning, ok, error]);
             expect(worst).to.be.equal(error);
         });
     });
 });
 
-function d(severity: number, message = 'A problem occurred.', ...children: Diagnostic[]): Diagnostic {
+function diag(severity: number, message = 'A problem occurred.', ...children: Diagnostic[]): Diagnostic {
     return {
         severity,
         message,

--- a/packages/modelserver-client/src/subscription-listener.ts
+++ b/packages/modelserver-client/src/subscription-listener.ts
@@ -179,6 +179,7 @@ export class NotificationSubscriptionListenerV2 extends NotificationSubscription
             switch (type) {
                 case MessageType.incrementalUpdate: {
                     this.notificationListener.onIncrementalUpdateV2?.({
+                        type: message.type,
                         modelUri,
                         patch: MessageDataMapper.as(message, Operations.isPatch)
                     });

--- a/packages/modelserver-client/src/utils/patch-utils.ts
+++ b/packages/modelserver-client/src/utils/patch-utils.ts
@@ -67,7 +67,8 @@ export function create(modeluri: string, parent: ModelServerObjectV2, feature: s
  * @param value the element to add
  * @returns The Json Patch AddOperation to add the element in the parent.
  */
- export function add(modeluri: string, parent: ModelServerObjectV2, feature: string, value: ModelServerObjectV2 | ModelServerReferenceDescriptionV2): AddOperation<ModelServerObjectV2> {
+export function add(modeluri: string, parent: ModelServerObjectV2, feature: string,
+    value: ModelServerObjectV2 | ModelServerReferenceDescriptionV2): AddOperation<ModelServerObjectV2> {
     return {
         op: 'add',
         path: getPropertyPath(modeluri, parent, feature),

--- a/packages/modelserver-client/src/utils/patch-utils.ts
+++ b/packages/modelserver-client/src/utils/patch-utils.ts
@@ -1,0 +1,149 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+
+import { ModelServerObjectV2 } from '../model/base-model';
+import { ReplaceOperation, AddOperation, RemoveOperation, Operation } from 'fast-json-patch';
+import { TypeGuard } from './type-util';
+
+// Utility methods to create Json Patches
+
+/**
+ * The definition of a Type. Used e.g. to indicate which type of object
+ * should be created, for a Create operation.
+ */
+export interface TypeDefinition {
+    $type: string;
+}
+
+/**
+ * Create a ReplaceOperation, to change the value of a property of the specified object.
+ * @param modeluri the uri of the model to edit
+ * @param object the object to edit
+ * @param feature the property to edit
+ * @param value the value to set
+ * @returns The Json Patch ReplaceOperation to set the property.
+ */
+export function replace<T>(modeluri: string, object: ModelServerObjectV2, feature: string, value: T): ReplaceOperation<T> {
+    return {
+        op: 'replace',
+        path: getPropertyPath(modeluri, object, feature),
+        value: value
+    };
+}
+
+/**
+ * Create an AddOperation, to create a new object of the specified type, in the specified parent.
+ * @param modeluri the uri of the model to edit
+ * @param parent the parent in which the new element should be created
+ * @param feature the property of the parent in which the new element should be added
+ * @param value the type of element to create
+ * @returns The Json Patch AddOperation to create the element.
+ */
+export function create(modeluri: string, parent: ModelServerObjectV2, feature: string, $type: string): AddOperation<TypeDefinition> {
+    return {
+        op: 'add',
+        path: getPropertyPath(modeluri, parent, feature),
+        value: {
+            $type: $type
+        }
+    };
+}
+
+/**
+ * Create a RemoveOperation, to delete an object from the model.
+ * @param modeluri the uri of the model to edit
+ * @param object the object to remove from the model
+ * @returns The Json Patch RemoveOperation to remove the element.
+ */
+export function deleteElement(modeluri: string, object: ModelServerObjectV2): RemoveOperation {
+    return {
+        op: 'remove',
+        path: getObjectPath(modeluri, object)
+    };
+}
+
+/**
+ * Create a RemoveOperation, to remove a value from a list.
+ * @param modeluri the uri of the model to edit
+ * @param object the object from which a value will be removed
+ * @param feature the property from which a value will be removed
+ * @param index the index of the value to remove
+ */
+export function removeValueAt(modeluri: string, object: ModelServerObjectV2, feature: string, index: number): RemoveOperation {
+    return {
+        op: 'remove',
+        path: getPropertyPath(modeluri, object, feature, index)
+    };
+}
+
+/**
+ * Create a RemoveOperation, to remove a value from a list.
+ * @param modeluri the uri of the model to edit
+ * @param object the object from which a value will be removed
+ * @param feature the property from which a value will be removed
+ * @param index the value to remove
+ */
+export function removeValue(modeluri: string, object: ModelServerObjectV2, feature: string, value: any): RemoveOperation | undefined {
+    const index = findIndex(object, feature, value);
+    if (index >= 0) {
+        return removeValue(modeluri, object, feature, index);
+    }
+    return undefined;
+}
+
+export function getObjectPath(modeluri: string, object: ModelServerObjectV2): string {
+    return `${modeluri}#${object.$id}`;
+}
+
+export function getPropertyPath(modeluri: string, object: ModelServerObjectV2, feature: string, index?: number): string {
+    const indexSuffix = index === undefined ? '' : `/${index}`;
+    return `${getObjectPath(modeluri, object)}/${feature}${indexSuffix}`;
+}
+
+function findIndex(object: ModelServerObjectV2, feature: string, value: any): number {
+    const propertyValue = (object as any)[feature];
+    if (Array.isArray(propertyValue)) {
+        return propertyValue.indexOf(value);
+    }
+    return -1;
+}
+
+/**
+ * Utility functions for working with JSON Patch operations.
+ */
+export namespace Operations {
+    export function isOperation(object: any): object is Operation {
+        return (
+            'op' in object &&
+            typeof object.op === 'string' && //
+            'path' in object &&
+            typeof object.path === 'string'
+        );
+    }
+
+    export function isPatch(object: any): object is Operation[] {
+        return (Array.isArray(object) && object.length === 0) || isOperation(object[0]);
+    }
+
+    /** Type guard testing whether an operation is a replace operation, with a nested guard on the value type. */
+    export function isReplace(op: Operation, typeGuard: 'string'): op is ReplaceOperation<string>;
+    export function isReplace(op: Operation, typeGuard: 'number'): op is ReplaceOperation<number>;
+    export function isReplace(op: Operation, typeGuard: 'boolean'): op is ReplaceOperation<boolean>;
+    export function isReplace<T = unknown>(op: Operation, typeGuard?: string | TypeGuard<T>): op is ReplaceOperation<T> {
+        if (typeof typeGuard === 'function') {
+            return op?.op === 'replace' && (!typeGuard || typeGuard(op.value));
+        }
+        if (!typeGuard) {
+            return op?.op === 'replace';
+        }
+        return op?.op === 'replace' && typeof op.value === typeGuard;
+    }
+}

--- a/packages/modelserver-client/src/utils/patch-utils.ts
+++ b/packages/modelserver-client/src/utils/patch-utils.ts
@@ -8,9 +8,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *********************************************************************************/
+import { AddOperation, Operation, RemoveOperation, ReplaceOperation } from 'fast-json-patch';
 
 import { ModelServerObjectV2 } from '../model/base-model';
-import { ReplaceOperation, AddOperation, RemoveOperation, Operation } from 'fast-json-patch';
 import { TypeGuard } from './type-util';
 
 // Utility methods to create Json Patches
@@ -44,15 +44,17 @@ export function replace<T>(modeluri: string, object: ModelServerObjectV2, featur
  * @param modeluri the uri of the model to edit
  * @param parent the parent in which the new element should be created
  * @param feature the property of the parent in which the new element should be added
- * @param value the type of element to create
+ * @param $type the type of element to create
+ * @param attributes the attributes to initialize for the new element
  * @returns The Json Patch AddOperation to create the element.
  */
-export function create(modeluri: string, parent: ModelServerObjectV2, feature: string, $type: string): AddOperation<TypeDefinition> {
+export function create(modeluri: string, parent: ModelServerObjectV2, feature: string, $type: string, attributes?: any): AddOperation<TypeDefinition> {
     return {
         op: 'add',
         path: getPropertyPath(modeluri, parent, feature),
         value: {
-            $type: $type
+            $type: $type,
+            ...attributes
         }
     };
 }
@@ -97,6 +99,18 @@ export function removeValue(modeluri: string, object: ModelServerObjectV2, featu
         return removeValue(modeluri, object, feature, index);
     }
     return undefined;
+}
+
+/**
+ * Create a RemoveOperation, to delete an object from the model.
+ * @param modeluri the uri of the model to edit
+ * @param objectToRemove the object to delete from the model
+ */
+export function removeObject(modeluri: string, objectToRemove: ModelServerObjectV2): RemoveOperation {
+    return {
+        op: 'remove',
+        path: getObjectPath(modeluri, objectToRemove)
+    };
 }
 
 export function getObjectPath(modeluri: string, object: ModelServerObjectV2): string {

--- a/packages/modelserver-client/src/utils/patch-utils.ts
+++ b/packages/modelserver-client/src/utils/patch-utils.ts
@@ -10,7 +10,7 @@
  *********************************************************************************/
 import { AddOperation, Operation, RemoveOperation, ReplaceOperation } from 'fast-json-patch';
 
-import { ModelServerObjectV2 } from '../model/base-model';
+import { ModelServerObjectV2, ModelServerReferenceDescriptionV2 } from '../model/base-model';
 import { TypeGuard } from './type-util';
 
 // Utility methods to create Json Patches
@@ -55,6 +55,25 @@ export function create(modeluri: string, parent: ModelServerObjectV2, feature: s
         value: {
             $type: $type,
             ...attributes
+        }
+    };
+}
+
+/**
+ * Create an AddOperation, to add an existing object of the specified type, in the specified parent.
+ * @param modeluri the uri of the model to edit
+ * @param parent the parent in which the element should be added
+ * @param feature the property of the parent in which the element should be added
+ * @param value the element to add
+ * @returns The Json Patch AddOperation to add the element in the parent.
+ */
+ export function add(modeluri: string, parent: ModelServerObjectV2, feature: string, value: ModelServerObjectV2 | ModelServerReferenceDescriptionV2): AddOperation<ModelServerObjectV2> {
+    return {
+        op: 'add',
+        path: getPropertyPath(modeluri, parent, feature),
+        value: {
+            $type: value.$type,
+            $id: getObjectPath(modeluri, value)
         }
     };
 }
@@ -113,8 +132,9 @@ export function removeObject(modeluri: string, objectToRemove: ModelServerObject
     };
 }
 
-export function getObjectPath(modeluri: string, object: ModelServerObjectV2): string {
-    return `${modeluri}#${object.$id}`;
+export function getObjectPath(modeluri: string, object: ModelServerObjectV2 | ModelServerReferenceDescriptionV2): string {
+    const id = ModelServerReferenceDescriptionV2.is(object) ? object.$ref : object.$id;
+    return `${modeluri}#${id}`;
 }
 
 export function getPropertyPath(modeluri: string, object: ModelServerObjectV2, feature: string, index?: number): string {

--- a/packages/modelserver-client/src/utils/type-util.spec.ts
+++ b/packages/modelserver-client/src/utils/type-util.spec.ts
@@ -1,0 +1,73 @@
+/*********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *********************************************************************************/
+import { expect } from 'chai';
+import { encode } from './type-util';
+
+describe('tests for type-util', () => {
+
+    describe('encode', () => {
+        it('JSON v1 as JSON v1', () => {
+            const object = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const encoded = encode('json')(object);
+            expect(encoded).to.be.equal(encoded);
+        });
+
+        it('JSON v1 as JSON v2', () => {
+            const object = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const expected = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const encoded = encode('json-v2')(object);
+            expect(encoded).to.be.eql(expected);
+        });
+
+        it('JSON v2 as JSON v1', () => {
+            const object = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const expected = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const encoded = encode('json')(object);
+            expect(encoded).to.be.eql(expected);
+        });
+
+        it('JSON v2 as JSON v2', () => {
+            const object = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const encoded = encode('json-v2')(object);
+            expect(encoded).to.be.equal(encoded);
+        });
+    });
+
+    describe('encode string', () => {
+        it('JSON v1 as JSON v1', () => {
+            const object = JSON.stringify({ eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
+            const encoded = encode('json')(object);
+            expect(encoded).to.be.equal(encoded);
+        });
+
+        it('JSON v1 as JSON v2', () => {
+            const object = JSON.stringify({ eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
+            const expected = { $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}};
+            const encoded = encode('json-v2')(object);
+            expect(encoded).to.be.a('string');
+            expect(JSON.parse(encoded as string)).to.be.eql(expected);
+        });
+
+        it('JSON v2 as JSON v1', () => {
+            const object = JSON.stringify({ $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
+            const expected = { eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}};
+            const encoded = encode('json')(object);
+            expect(encoded).to.be.a('string');
+            expect(JSON.parse(encoded as string)).to.be.eql(expected);
+        });
+
+        it('JSON v2 as JSON v2', () => {
+            const object = JSON.stringify({ $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
+            const encoded = encode('json-v2')(object);
+            expect(encoded).to.be.equal(encoded);
+        });
+    });
+});

--- a/packages/modelserver-client/src/utils/type-util.ts
+++ b/packages/modelserver-client/src/utils/type-util.ts
@@ -312,6 +312,5 @@ function traverse<T>(object: any, fn: (target: any, props: string[]) => T | unde
 }
 
 function isNonEmptyObjectArray(value: any): value is AnyObject[] {
-    // TODO: More correct would be value.every(e => typeof e === 'object' && !Array.isArray(value[0]))
     return Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && !Array.isArray(value[0]);
 }

--- a/packages/modelserver-client/src/utils/type-util.ts
+++ b/packages/modelserver-client/src/utils/type-util.ts
@@ -10,6 +10,7 @@
  *********************************************************************************/
 import { Format, JsonFormat } from '../model-server-client-api-v2';
 import { Model } from '../model-server-message';
+
 /**
  * The built-in 'object' & 'Object' types are currently hard to use
  * an should be avoided. It's recommended to use Record instead to describe the
@@ -310,7 +311,7 @@ function traverse<T>(object: any, fn: (target: any, props: string[]) => T | unde
     return false;
 }
 
-function isNonEmptyObjectArray(value: any): value is object[] {
+function isNonEmptyObjectArray(value: any): value is AnyObject[] {
     // TODO: More correct would be value.every(e => typeof e === 'object' && !Array.isArray(value[0]))
     return Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && !Array.isArray(value[0]);
 }

--- a/packages/modelserver-client/src/utils/type-util.ts
+++ b/packages/modelserver-client/src/utils/type-util.ts
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *********************************************************************************/
-import { Format, JsonFormat } from '../model-server-client-api-v2';
+import { Format, FORMAT_JSON_V1, FORMAT_JSON_V2, FORMAT_XMI, JsonFormat } from '../model-server-client-api-v2';
 import { Model } from '../model-server-message';
 
 /**
@@ -170,11 +170,11 @@ export function encodeRequestBody(format: Format): Encoder<{ data: any }> {
  */
 export function encode(format: Format): Encoder {
     switch (format) {
-        case 'xml':
+        case FORMAT_XMI:
             return asXML;
-        case 'json':
+        case FORMAT_JSON_V1:
             return handleString(asJsonV1);
-        case 'json-v2':
+        case FORMAT_JSON_V2:
             return handleString(asJsonV2);
         default:
             throw new Error(`Unsupported message format: ${format}`);
@@ -208,11 +208,11 @@ function asXML(object: string | AnyObject): string {
 }
 
 function asJsonV1(object: AnyObject): any {
-    return isJsonV1(object) ? object : copy(object, 'json');
+    return isJsonV1(object) ? object : copy(object, FORMAT_JSON_V1);
 }
 
 function asJsonV2(object: AnyObject): any {
-    return isJsonV2(object) ? object : copy(object, 'json-v2');
+    return isJsonV2(object) ? object : copy(object, FORMAT_JSON_V2);
 }
 
 function isJsonV1(object: AnyObject): boolean {
@@ -241,10 +241,10 @@ function copy(object: any, format: JsonFormat): any {
     const copier = (target: any): void => {
         const theCopy = { ...target };
 
-        if (format === 'json' && '$type' in theCopy) {
+        if (format === FORMAT_JSON_V1 && '$type' in theCopy) {
             theCopy.eClass = theCopy.$type;
             delete theCopy.$type;
-        } else if (format === 'json-v2' && 'eClass' in theCopy) {
+        } else if (format === FORMAT_JSON_V2 && 'eClass' in theCopy) {
             theCopy.$type = theCopy.eClass;
             delete theCopy.eClass;
         }

--- a/packages/modelserver-theia/src/browser/frontend-module.ts
+++ b/packages/modelserver-theia/src/browser/frontend-module.ts
@@ -12,6 +12,7 @@ import { ModelServerClient } from '@eclipse-emfcloud/modelserver-client';
 import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
 
+import { ModelServerSubscriptionClientV2 } from '.';
 import { MODEL_SERVER_CLIENT_SERVICE_PATH, ModelServerFrontendClient, TheiaModelServerClient } from '../common';
 import { ModelServerFrontendContribution } from './model-server-frontend-contribution';
 import { ModelServerSubscriptionClient, ModelServerSubscriptionService } from './model-server-subscription-client';
@@ -28,4 +29,9 @@ export default new ContainerModule(bind => {
             const client: ModelServerFrontendClient = ctx.container.get(ModelServerFrontendClient);
             return connection.createProxy<ModelServerClient>(MODEL_SERVER_CLIENT_SERVICE_PATH, client);
         }).inSingletonScope();
+});
+
+export const FrontendModuleV2 = new ContainerModule((bind, _unbind, _isBound, rebind) => {
+    bind(ModelServerSubscriptionClientV2).toSelf().inSingletonScope();
+    rebind(ModelServerSubscriptionClient).toService(ModelServerSubscriptionClientV2);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4449,6 +4449,11 @@ fast-glob@^3.2.5, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-json-patch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.0.tgz#ec8cd9b9c4c564250ec8b9140ef7a55f70acaee6"
+  integrity sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
Note: the PR is based on the standalone client PR #69 

This is the client changes to support the V2 ModelServer API. The changes are described on the corresponding Model Server pull request: eclipse-emfcloud/emfcloud-modelserver/pull/151

Contributed on behalf of STMicroelectronics.