### PR TITLE
#150 Use PUT request for full model update

### DIFF
--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -161,7 +161,7 @@ describe('tests for ModelServerClientV2', () => {
 
             moxios.wait(() => {
                 let request = moxios.requests.at(0);
-                expect(request.config.method).to.be.equal('patch');
+                expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
                 expect(request.config.baseURL).to.be.equal(baseUrl);

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -148,14 +148,14 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
             if (typeof formatOrGuard === 'function') {
                 const typeGuard = formatOrGuard;
                 return this.process(
-                    this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+                    this.restClient.put(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
                     msg => MessageDataMapper.as(msg, typeGuard)
                 );
             }
             format = formatOrGuard;
         }
         return this.process(
-            this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
+            this.restClient.put(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }),
             MessageDataMapper.asObject
         );
     }


### PR DESCRIPTION
v2 API specifies `PUT` on /models endpoint, not `PATCH`,  to perform a full model update.
