### PR TITLE
Fix #85: Exception on JSON containing null

### DIFF
--- a/packages/modelserver-client/src/utils/type-util.spec.ts
+++ b/packages/modelserver-client/src/utils/type-util.spec.ts
@@ -14,58 +14,70 @@ import { encode } from './type-util';
 describe('tests for type-util', () => {
 
     describe('encode', () => {
+        const emptyArray: any[] = [];
+        const tags = ['high-prio', 'red'];
+        // eslint-disable-next-line no-null/no-null
+        const nada = null; // JSON uses null
+        const emptyObj = {};
+
         it('JSON v1 as JSON v1', () => {
-            const object = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const object = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}]};
             const encoded = encode('json')(object);
             expect(encoded).to.be.equal(encoded);
         });
 
         it('JSON v1 as JSON v2', () => {
-            const object = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
-            const expected = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const object = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}]};
+            const expected = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}]};
             const encoded = encode('json-v2')(object);
             expect(encoded).to.be.eql(expected);
         });
 
         it('JSON v2 as JSON v1', () => {
-            const object = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
-            const expected = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const object = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}]};
+            const expected = { eClass: 'Foo', name: 'test', nested: [{ eClass: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}]};
             const encoded = encode('json')(object);
             expect(encoded).to.be.eql(expected);
         });
 
         it('JSON v2 as JSON v2', () => {
-            const object = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}]};
+            const object = { $type: 'Foo', name: 'test', nested: [{ $type: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}]};
             const encoded = encode('json-v2')(object);
             expect(encoded).to.be.equal(encoded);
         });
     });
 
     describe('encode string', () => {
+        const emptyArray: any[] = [];
+        const tags = ['high-prio', 'red'];
+        // eslint-disable-next-line no-null/no-null
+        const nada = null; // JSON uses null
+        const emptyObj = {};
+
         it('JSON v1 as JSON v1', () => {
-            const object = JSON.stringify({ eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
+            const object = JSON.stringify({ eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}});
             const encoded = encode('json')(object);
             expect(encoded).to.be.equal(encoded);
         });
 
         it('JSON v1 as JSON v2', () => {
-            const object = JSON.stringify({ eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
-            const expected = { $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}};
+            const object = JSON.stringify({ eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}});
+            const expected = { $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}};
             const encoded = encode('json-v2')(object);
             expect(encoded).to.be.a('string');
             expect(JSON.parse(encoded as string)).to.be.eql(expected);
         });
 
         it('JSON v2 as JSON v1', () => {
-            const object = JSON.stringify({ $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
-            const expected = { eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags: ['high-prio', 'red']}};
+            const object = JSON.stringify({ $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}});
+            const expected = { eClass: 'Foo', name: 'test', nested: { eClass: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}};
             const encoded = encode('json')(object);
             expect(encoded).to.be.a('string');
             expect(JSON.parse(encoded as string)).to.be.eql(expected);
         });
 
         it('JSON v2 as JSON v2', () => {
-            const object = JSON.stringify({ $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags: ['high-prio', 'red']}});
+            const object = JSON.stringify({ $type: 'Foo', name: 'test', nested: { $type: 'Nested', name: 'inner', tags, emptyArray, nada, emptyObj}});
             const encoded = encode('json-v2')(object);
             expect(encoded).to.be.equal(encoded);
         });

--- a/packages/modelserver-client/src/utils/type-util.ts
+++ b/packages/modelserver-client/src/utils/type-util.ts
@@ -282,6 +282,11 @@ function copy(object: any, format: JsonFormat): any {
 }
 
 function traverse<T>(object: any, fn: (target: any, props: string[]) => T | undefined, visited = new Set()): boolean {
+    // Only traverse into objects. Null, undefined, strings, numbers, booleans are primitive values in JSON and functions don't exist.
+    // eslint-disable-next-line no-null/no-null
+    if (typeof object !== 'object' || object === null) { // JSON uses null
+        return false;
+    }
     if (visited.has(object)) {
         return false;
     }


### PR DESCRIPTION
Skip over all primitive and primitive-like values, including null
which actually is an object, in the traversal of JSON documents.
Also add coverage of empty objects and empty arrays to the
tests to ensure that they are faithfully copied.

Contributed on behalf of STMicroelectronics.
