### PR TITLE
Model Server API v2 in Theia services

### DIFF
--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -40,6 +40,20 @@ export type JsonFormat = 'json' | 'json-v2';
 export type Format = string;
 
 /**
+ * Additional subscription options supported by API v2 model subscriptions.
+ */
+export interface SubscriptionOptionsV2 extends SubscriptionOptions {
+    /**
+     * The scheme to use in the `path` property of {@link Operation}s in the
+     * JSON Patches reported by API V2 queries. Supported values (case insensitive)
+     * include `'jsonPointer'` (the default for standard JSON Patches) and
+     * `'uriFragments'` (for a custom EMF-specific scheme based on the URI
+     * fragments of `EObject`s) .
+     */
+    paths?: string;
+}
+
+/**
  * Basic client API to interact with a model server that conforms to the Modelserver API Version 2.
  */
 export interface ModelServerClientApiV2 {
@@ -107,7 +121,7 @@ export interface ModelServerClientApiV2 {
     redo(modeluri: string): Promise<ModelUpdateResult>;
 
     // WebSocket connection
-    subscribe(modeluri: string, listener: SubscriptionListener, options?: SubscriptionOptions): SubscriptionListener;
+    subscribe(modeluri: string, listener: SubscriptionListener, options?: SubscriptionOptionsV2): SubscriptionListener;
 
     send(modelUri: string, message: ModelServerMessage): void;
     unsubscribe(modelUri: string): void;

--- a/packages/modelserver-theia/src/common/protocol.ts
+++ b/packages/modelserver-theia/src/common/protocol.ts
@@ -8,11 +8,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-import { ModelServerClientApiV1 } from '@eclipse-emfcloud/modelserver-client';
+import {
+    ModelServerClientApiV1,
+    ModelServerClientApiV2,
+    SubscriptionListener,
+    SubscriptionOptionsV2
+} from '@eclipse-emfcloud/modelserver-client';
 import { JsonRpcServer } from '@theia/core';
 import WebSocket from 'isomorphic-ws';
 
 export const MODEL_SERVER_CLIENT_SERVICE_PATH = '/services/modelserverclient';
+export const MODEL_SERVER_CLIENT_V2_SERVICE_PATH = '/services/modelserverclient/v2';
 
 export const ModelServerFrontendClient = Symbol('ModelServerFrontendClient');
 export interface ModelServerFrontendClient {
@@ -24,3 +30,27 @@ export interface ModelServerFrontendClient {
 
 export const TheiaModelServerClient = Symbol('TheiaModelServerClient');
 export interface TheiaModelServerClient extends ModelServerClientApiV1, JsonRpcServer<ModelServerFrontendClient> {}
+
+export const TheiaModelServerClientV2 = Symbol('TheiaModelServerClientV2');
+export interface TheiaModelServerClientV2 extends ModelServerClientApiV2, JsonRpcServer<ModelServerFrontendClient> {
+    /**
+     * Subscribe to model notifications. In the Theia context, the `listener` parameter is optional because
+     * it defaults to the frontend client proxy.
+     *
+     * @param modeluri the URI of the model to which to subscribe
+     * @param listener the subscription listener. If omitted, the front-end client is substituted. This lets the
+     * client handle both Theia RPC events and the messages from the _Model Server_
+     * @param options optional subscription options, including message format, time-out, and message filtering
+     */
+    subscribe(modeluri: string, listener?: SubscriptionListener, options?: SubscriptionOptionsV2): SubscriptionListener;
+
+    /**
+     * Subscribe the frontend client of the remote `TheiaModelServerClientV2` service as
+     * the `SubscriptionListener` handler for model notifications. This is
+     * equivalent to passing `undefined` as the second argument to the {@link subscribe} method.
+     *
+     * @param modeluri the URI of the model to which to subscribe
+     * @param options optional subscription options, including message format, time-out, and message filtering
+     */
+    selfSubscribe(modeluri: string, options?: SubscriptionOptionsV2): void;
+}

--- a/packages/modelserver-theia/src/node/backend-module.ts
+++ b/packages/modelserver-theia/src/node/backend-module.ts
@@ -12,22 +12,51 @@ import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { ContainerModule } from '@theia/core/shared/inversify';
 
-import { MODEL_SERVER_CLIENT_SERVICE_PATH, ModelServerFrontendClient, TheiaModelServerClient } from '../common';
-import { DefaultModelServerLauncher, ModelServerLauncher } from './model-server-backend-contribution';
+import {
+    MODEL_SERVER_CLIENT_SERVICE_PATH,
+    MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
+    ModelServerFrontendClient,
+    TheiaModelServerClient,
+    TheiaModelServerClientV2
+} from '../common';
+import { LaunchOptions } from './launch-options';
+import { DefaultModelServerLauncher, DefaultModelServerNodeLauncher, ModelServerLauncher } from './model-server-backend-contribution';
 import { TheiaBackendModelServerClient } from './theia-model-server-client';
+import { TheiaBackendModelServerClientV2 } from './theia-model-server-client-v2';
 
 export default new ContainerModule(bind => {
     bind(DefaultModelServerLauncher).toSelf().inSingletonScope();
-    bind(ModelServerLauncher).toService(DefaultModelServerLauncher);
-    bind(BackendApplicationContribution).toService(DefaultModelServerLauncher);
+    bind(DefaultModelServerNodeLauncher).toSelf().inSingletonScope();
+    bind(ModelServerLauncher).toDynamicValue(({ container }) => {
+        // If we are configured to launch the modelserver-node, then bind that launcher,
+        // otherwise just the Java server launcher
+        if (container.isBound(LaunchOptions) && container.get<LaunchOptions>(LaunchOptions).modelServerNode) {
+            return container.get(DefaultModelServerNodeLauncher);
+        }
+        return container.get(DefaultModelServerLauncher);
+    });
+    bind(BackendApplicationContribution).toService(ModelServerLauncher);
 
     bind(TheiaModelServerClient).to(TheiaBackendModelServerClient).inSingletonScope();
-
     bind(ConnectionHandler)
         .toDynamicValue(
             ctx =>
                 new JsonRpcConnectionHandler<ModelServerFrontendClient>(MODEL_SERVER_CLIENT_SERVICE_PATH, client => {
                     const modelServerClient = ctx.container.get<TheiaModelServerClient>(TheiaModelServerClient);
+                    modelServerClient.setClient(client);
+                    client.onDidCloseConnection(() => modelServerClient.dispose());
+                    return modelServerClient;
+                })
+        )
+        .inSingletonScope();
+
+    // For Model Server API v2
+    bind(TheiaModelServerClientV2).to(TheiaBackendModelServerClientV2).inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler<ModelServerFrontendClient>(MODEL_SERVER_CLIENT_V2_SERVICE_PATH, client => {
+                    const modelServerClient = ctx.container.get<TheiaModelServerClientV2>(TheiaModelServerClientV2);
                     modelServerClient.setClient(client);
                     client.onDidCloseConnection(() => modelServerClient.dispose());
                     return modelServerClient;

--- a/packages/modelserver-theia/src/node/index.ts
+++ b/packages/modelserver-theia/src/node/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,3 +11,4 @@
 export * from './launch-options';
 export * from './model-server-backend-contribution';
 export * from './theia-model-server-client';
+export * from './theia-model-server-client-v2';

--- a/packages/modelserver-theia/src/node/launch-options.ts
+++ b/packages/modelserver-theia/src/node/launch-options.ts
@@ -16,10 +16,43 @@ export interface LaunchOptions {
     hostname: string;
     jarPath?: string;
     additionalArgs?: string[];
+
+    /**
+     * For a configuration including the `modelserver-node`, launch options
+     * specific to that server process.
+     */
+    modelServerNode?: ModelServerNodeOptions;
+}
+
+export interface ModelServerNodeOptions {
+    /**
+     * The port of the Java _Model Server_ to which the Node layer connects.
+     * In this case, the Java server is configured to listen on this port
+     * and the `serverPort` of the containing `LaunchOptions` is the port on
+     * which the `modelserver-node` is configured to listen.
+     */
+    upstreamPort: number;
+    /**
+     * The path of the Javascript main file to launch (often webpacked).
+     */
+    jsPath?: string;
+    /**
+     * Optional additional command-line arguments for the `modelserver-node` process.
+     */
+    additionalArgs?: string[];
 }
 
 export const DEFAULT_LAUNCH_OPTIONS: LaunchOptions = {
     baseURL: 'api/v1',
     serverPort: 8081,
     hostname: 'localhost'
+};
+
+export const DEFAULT_MODELSERVER_NODE_LAUNCH_OPTIONS: LaunchOptions & Pick<Required<LaunchOptions>, 'modelServerNode'> = {
+    baseURL: 'api/v2',
+    serverPort: 8082,
+    hostname: 'localhost',
+    modelServerNode: {
+        upstreamPort: 8081
+    }
 };

--- a/packages/modelserver-theia/src/node/theia-model-server-client-v2.ts
+++ b/packages/modelserver-theia/src/node/theia-model-server-client-v2.ts
@@ -1,0 +1,143 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+import {
+    AddCommand,
+    CompoundCommand,
+    ModelServerClientV2,
+    ModelServerCommand,
+    ModelUpdateResult,
+    Operations,
+    RemoveCommand,
+    SetCommand,
+    SubscriptionListener,
+    SubscriptionOptionsV2
+} from '@eclipse-emfcloud/modelserver-client';
+import { decorate, inject, injectable, optional } from '@theia/core/shared/inversify';
+import { Operation } from 'fast-json-patch';
+import { CancellationToken } from 'vscode-jsonrpc';
+
+import { ModelServerFrontendClient, TheiaModelServerClientV2 } from '../common';
+import { DEFAULT_MODELSERVER_NODE_LAUNCH_OPTIONS, LaunchOptions } from './launch-options';
+
+decorate(injectable(), ModelServerClientV2);
+
+@injectable()
+export class TheiaBackendModelServerClientV2 extends ModelServerClientV2 implements TheiaModelServerClientV2 {
+    protected subscriptionClient?: ModelServerFrontendClient;
+
+    constructor(
+        @inject(LaunchOptions) @optional() protected readonly launchOptions: LaunchOptions = DEFAULT_MODELSERVER_NODE_LAUNCH_OPTIONS
+    ) {
+        super();
+        const baseUrl = this.getBaseUrl();
+        this.initialize(baseUrl);
+    }
+
+    dispose(): void {
+        Array.from(this.openSockets.values()).forEach(openSocket => openSocket.close());
+    }
+
+    protected getBaseUrl(): string {
+        // We construct URLs by prepending and appending the base URL with '/' separators, so make
+        // sure that we won't be repeating those separators else we'll get 404s
+        const optionsUrl = trimSeparators(this.launchOptions.baseURL);
+        const baseUrl = `http://${this.launchOptions.hostname}:${this.launchOptions.serverPort}/${optionsUrl}`;
+        return baseUrl;
+    }
+
+    setClient(client: ModelServerFrontendClient | undefined): void {
+        this.subscriptionClient = client;
+    }
+
+    subscribe(modeluri: string, listener?: SubscriptionListener, options: SubscriptionOptionsV2 = {}): SubscriptionListener {
+        // Handle optional arguments finding the RPC cancellation token in their place
+        if (CancellationToken.is(listener)) {
+            listener = undefined;
+        } else if (CancellationToken.is(options)) {
+            options = {};
+        }
+
+        if (!listener && options.listener) {
+            // Handle the v1 behaviour
+            listener = options.listener;
+            delete options.listener;
+        }
+
+        if (!listener) {
+            // Could still be undefined if not in the options
+            listener = this.subscriptionClient;
+        }
+
+        return super.subscribe(modeluri, listener!, options);
+    }
+
+    selfSubscribe(modeluri: string, options: SubscriptionOptionsV2 = {}): void {
+        // Handle optional arguments finding the RPC cancellation token in their place
+        if (CancellationToken.is(options)) {
+            options = {};
+        }
+
+        this.subscribe(modeluri, undefined, options);
+    }
+
+    edit(modeluri: string, patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<ModelUpdateResult> {
+        if (ModelServerCommand.is(patchOrCommand)) {
+            return super.edit(modeluri, ensureCommandPrototype(patchOrCommand));
+        }
+        if (Operations.isOperation(patchOrCommand)) {
+            return super.edit(modeluri, patchOrCommand);
+        }
+        return super.edit(modeluri, patchOrCommand);
+    }
+}
+
+/**
+ * The client API that we extend expects actual instance-of relationships
+ * in the command classes, but we lose the prototype chain when sending
+ * commands over the RPC wire from the frontend to the backend. So this
+ * function restores the correct prototype to a `command`.
+ *
+ * @param command a command that came from the Theia frontend
+ * @returns the `command`, now with the expected prototype chain
+ */
+function ensureCommandPrototype<T extends ModelServerCommand>(command: T): T {
+    if (SetCommand.is(command)) {
+        Object.setPrototypeOf(command, SetCommand.prototype);
+    } else if (AddCommand.is(command)) {
+        Object.setPrototypeOf(command, AddCommand.prototype);
+    } else if (RemoveCommand.is(command)) {
+        Object.setPrototypeOf(command, RemoveCommand.prototype);
+    } else if (CompoundCommand.is(command)) {
+        Object.setPrototypeOf(command, CompoundCommand.prototype);
+        (command as CompoundCommand).commands.forEach(ensureCommandPrototype);
+    }
+    return command;
+}
+
+/**
+ * We construct URLs by prepending and appending the base URL with '/' separators, so
+ * this function trims any leading and trailing separators to make sure that we won't
+ * be repeating those separators else we'll get 404s.
+ *
+ * @param url the URL to trim
+ * @returns the trimmed URL
+ */
+function trimSeparators(url: string | undefined): string | undefined {
+    if (url) {
+        while (url.startsWith('/')) {
+            url = url.substring(1);
+        }
+        while (url.endsWith('/')) {
+            url = url.substring(0, url.length - 1);
+        }
+    }
+    return url;
+}

--- a/packages/modelserver-theia/src/node/theia-model-server-client.ts
+++ b/packages/modelserver-theia/src/node/theia-model-server-client.ts
@@ -10,6 +10,7 @@
  *******************************************************************************/
 import { ModelServerClient, SubscriptionOptions } from '@eclipse-emfcloud/modelserver-client';
 import { decorate, inject, injectable, optional } from '@theia/core/shared/inversify';
+import { CancellationToken } from 'vscode-jsonrpc';
 
 import { ModelServerFrontendClient, TheiaModelServerClient } from '../common';
 import { DEFAULT_LAUNCH_OPTIONS, LaunchOptions } from './launch-options';
@@ -36,6 +37,11 @@ export class TheiaBackendModelServerClient extends ModelServerClient implements 
     }
 
     subscribe(modeluri: string, options: SubscriptionOptions = {}): void {
+        // Handle optional arguments finding the RPC cancellation token in their place
+        if (CancellationToken.is(options)) {
+            options = {};
+        }
+
         if (!options.listener) {
             options.listener = this.subscriptionClient;
         }


### PR DESCRIPTION
Add a variant of the Theia-integrated services for _Model Server_ API v2, including:

- `TheiaModelServerClientV2` implementing the RPC service for `ModelServerClientApiV2` on a service path that is distinct from the original `TheiaModelServerClient`
- new subscription option for API v2 to select the JSON Patch `path` scheme in incremental update notifications
- new launch options for the `modelserver-node` process
- new backend server launcher implementation that is bound dynamically when the options include the modelserver-node. This actually fixes at least a part of eclipse-emfcloud/modelserver-node#20

The new `TheiaBackendModelServerClientV2` implementation accounts for the cancellation token replacing optional arguments that the remote caller omits. The same is done retroactively in the original `TheiaBackendModelServerClient` for robustness.

Fixes #88.

Contributed on behalf of STMicroelectronics.
