### PR TITLE
#101 Model Server Launcher extensibility

### DIFF
--- a/packages/modelserver-theia/src/node/launch-options.ts
+++ b/packages/modelserver-theia/src/node/launch-options.ts
@@ -15,7 +15,14 @@ export interface LaunchOptions {
     serverPort: number;
     hostname: string;
     jarPath?: string;
+    /**
+     * Additional arguments, besides those implied by other options, passed to server main entrypoint.
+     */
     additionalArgs?: string[];
+    /**
+     * Arguments passed to the Java Virtual Machine, not to the server application `main` entrypoint.
+     */
+    vmArgs?: string[];
 
     /**
      * For a configuration including the `modelserver-node`, launch options


### PR DESCRIPTION
Implement the suggested extensibility hooks for subclasses to selectively override Java server and/or Node server launching. Also, because it's a related subject, fix the port assignment for the Java server in the two-server scenario allowing for subclasses also to override that.

Fixes #101.
Fixes #100.

Contributed on behalf of STMicroelectronics.
