### PR TITLE
209: API V2: Return patches for each affected resource

### DIFF
--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -132,6 +132,21 @@ export namespace ModelServerClientApiV2 {
 }
 
 /**
+ * A patch affecting a specific model.
+ */
+export interface ModelPatch {
+    /**
+     * The uri of the patched model.
+     */
+    modelUri: string;
+
+    /**
+     * The patch describing the changes applied to the model.
+     */
+    patch: Operation[];
+}
+
+/**
  * Result sent to client after requesting a model update.
  */
 export interface ModelUpdateResult {
@@ -149,13 +164,24 @@ export interface ModelUpdateResult {
      * @param copy by default, the patch will be directly applied to the oldModel, modifying
      * it in-place. If copy is true, the patch will be applied on a copy of the model, leaving
      * the original model unchanged.
+     * @param modelUri the uri of the model to patch. This can be used when the model is split in multiple
+     * resources, to identify the patch to apply. The modelUri should correspond to the oldModel object.
+     * It can be omitted when patching the main model (or in single-model cases).
      * @return the patched model.
      */
-    patchModel?(oldModel: ModelServerElement, copy?: boolean): ModelServerElement;
+    patchModel?(oldModel: ModelServerElement, copy?: boolean, modelUri?: string): ModelServerElement;
 
     /**
      * The Json Patch describing the changes that were applied to the model. Only present if
      * the edit request was successful.
      */
     patch?: Operation[];
+
+    /**
+     * The list of Json Patches describing the changes that were applied to the models. Only present if
+     * the edit request was successful.
+     *
+     * The list contains one entry per modified model. Unmodified models will not contain any entry.
+     */
+    allPatches?: ModelPatch[];
 }

--- a/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
@@ -355,5 +355,37 @@ describe('Integration tests for ModelServerClientV2', () => {
 
             await testUndoRedo(modeluri, machine, model);
         });
+
+        it('check all patch replies', async () => {
+            const modeluri = 'SuperBrewer3000.coffee';
+            const newName = 'Super Brewer 6000';
+            const machine = await client.get(modeluri, ModelServerObjectV2.is);
+
+            const patchedMachine = deepClone(machine);
+
+            // Directly change the model
+            patchedMachine.name = newName;
+            patchedMachine.children[1].processor.clockSpeed = 6;
+
+            // Generate patch by diffing the original model and the patched one
+            const patch = jsonpatch.compare(machine, patchedMachine);
+
+            const result = await client.edit(modeluri, patch);
+            expect(result.success).to.be.true;
+
+            expect(result.patch).to.not.be.undefined;
+            expect(result.allPatches).to.not.be.undefined;
+            expect(result.allPatches).to.be.an('array').of.length(1);
+
+            // Patch the main resource
+            const updatedMachineMainPatch = result.patchModel!(machine, true);
+            expect(patchedMachine).to.deep.equal(updatedMachineMainPatch);
+
+            // Patch the first resource
+            const updatedMachineFirstPatch = result.patchModel!(machine, true, result.allPatches![0].modelUri);
+            expect(patchedMachine).to.deep.equal(updatedMachineFirstPatch);
+
+            await testUndoRedo(modeluri, machine, updatedMachineFirstPatch);
+        });
     });
 });

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { Operation } from 'fast-json-patch';
+import { deepClone, Operation } from 'fast-json-patch';
 import WebSocket from 'isomorphic-ws';
 
 import { ModelServerCommand } from './model/command-model';
@@ -228,6 +228,14 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
                 type: 'modelserver.patch',
                 data: fullPatch
             };
+            if (fullPatch.length === 0) {
+                // No-op
+                return Promise.resolve({
+                    success: true,
+                    patchModel: (oldModel, copy, _modelUri) => (copy ? deepClone(oldModel) : oldModel),
+                    patch: []
+                });
+            }
         }
         return this.process(
             this.restClient.patch(ModelServerPaths.MODEL_CRUD, encodeRequestBody(this.defaultFormat)(patchMessage), {
@@ -257,7 +265,7 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
             const errorMsg = `${modeluri} : Cannot open new socket, already subscribed!'`;
             console.warn(errorMsg);
             if (options.errorWhenUnsuccessful) {
-                throw new Error('errorMsg');
+                throw new Error(errorMsg);
             }
         }
         const path = this.createSubscriptionPath(modeluri, options);


### PR DESCRIPTION
Update the model-server-client V2 to handle additional patches returned by the server during edit, undo and redo requests: https://github.com/eclipse-emfcloud/emfcloud-modelserver/pull/215

refs https://github.com/eclipse-emfcloud/emfcloud-modelserver/issues/209

Contributed on behalf of STMicroelectronics.