### PR TITLE
Fix baseUrl handling

### DIFF
--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -38,6 +38,18 @@ describe('tests for ModelServerClientV2', () => {
         const axios = client['restClient'];
         expect(axios.defaults.baseURL).to.be.equal(baseUrl);
     });
+    it('test createSubscriptionPath without trailing slash', () => {
+        client = new ModelServerClientV2();
+        client.initialize(baseUrl);
+        const subscriptionPath = client['createSubscriptionPath']('foo', {});
+        expect(subscriptionPath).to.be.equal(`ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2`);
+    });
+    it('test createSubscriptionPath with trailing slash', () => {
+        client = new ModelServerClientV2();
+        client.initialize(`${baseUrl}/`);
+        const subscriptionPath = client['createSubscriptionPath']('foo', {});
+        expect(subscriptionPath).to.be.equal(`ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2`);
+    });
 
     describe('test requests', () => {
         it('getAll', done => {

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -31,7 +31,7 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
     protected defaultFormat: Format = FORMAT_JSON_V2;
 
     initialize(baseUrl: string, defaultFormat: Format = FORMAT_JSON_V2): void | Promise<void> {
-        this._baseUrl = baseUrl;
+        this._baseUrl = baseUrl.endsWith('/') ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl;
         this.defaultFormat = defaultFormat;
         this.restClient = axios.create(this.getAxiosConfig(baseUrl));
     }

--- a/packages/modelserver-client/src/model-server-client.spec.ts
+++ b/packages/modelserver-client/src/model-server-client.spec.ts
@@ -38,6 +38,19 @@ describe('tests for ModelServerClient', () => {
         expect(axios.defaults.baseURL).to.be.equal(baseUrl);
     });
 
+    it('test createSubscriptionPath without trailing slash', () => {
+        client = new ModelServerClient();
+        client.initialize(baseUrl);
+        const subscriptionPath = client['createSubscriptionPath']('foo', {});
+        expect(subscriptionPath).to.be.equal(`ws://localhost:8081/api/v1/subscribe?modeluri=foo`);
+    });
+    it('test createSubscriptionPath with trailing slash', () => {
+        client = new ModelServerClient();
+        client.initialize(`${baseUrl}/`);
+        const subscriptionPath = client['createSubscriptionPath']('foo', {});
+        expect(subscriptionPath).to.be.equal(`ws://localhost:8081/api/v1/subscribe?modeluri=foo`);
+    });
+
     describe('test requests', () => {
         it('getAll', done => {
             client.getAll();

--- a/packages/modelserver-client/src/model-server-client.ts
+++ b/packages/modelserver-client/src/model-server-client.ts
@@ -29,7 +29,7 @@ export class ModelServerClient implements ModelServerClientApiV1 {
     protected defaultFormat = 'json';
 
     initialize(baseUrl: string): void | Promise<void> {
-        this._baseUrl = baseUrl;
+        this._baseUrl = baseUrl.endsWith('/') ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl;
         this.restClient = axios.create(this.getAxisConfig(baseUrl));
     }
 
@@ -218,7 +218,7 @@ export class ModelServerClient implements ModelServerClientApiV1 {
         }
         Object.entries(paramOptions).forEach(entry => queryParams.append(entry[0], entry[1]));
         queryParams.delete('errorWhenUnsuccessful');
-        return `${this._baseUrl}${ModelServerPaths.SUBSCRIPTION}?${queryParams.toString()}`.replace(/^(http|https):\/\//i, 'ws://');
+        return `${this._baseUrl}/${ModelServerPaths.SUBSCRIPTION}?${queryParams.toString()}`.replace(/^(http|https):\/\//i, 'ws://');
     }
 
     protected doSubscribe(listener: SubscriptionListener, modelUri: string, path: string): void {


### PR DESCRIPTION
The baseUrl did not handle trailing slashes correctly.
The V2 Client expected the baseUrl to not have a trailing slash.
The V1 Client expected the baseUrl to have a trailing slash.

With the fix the trailing slash is always removed and added during the
calculation of the subscription path.

Fixes #99