### PR TITLE
159: API V2: Properly define and support multi-resources patches/operations

### DIFF
--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -54,6 +54,16 @@ export interface SubscriptionOptionsV2 extends SubscriptionOptions {
 }
 
 /**
+ * A union type that represents all Patches or Commands supported by the model server:
+ * - Operation
+ * - Operation[] (Json Patch)
+ * - ModelPatch
+ * - ModelPatch[]
+ * - ModelServerCommand
+ */
+export type PatchOrCommand = Operation | Operation[] | ModelPatch | ModelPatch[] | ModelServerCommand;
+
+/**
  * Basic client API to interact with a model server that conforms to the Modelserver API Version 2.
  */
 export interface ModelServerClientApiV2 {
@@ -113,8 +123,7 @@ export interface ModelServerClientApiV2 {
 
     ping(): Promise<boolean>;
 
-    edit(modeluri: string, patch: Operation | Operation[], format?: Format): Promise<ModelUpdateResult>;
-    edit(modeluri: string, command: ModelServerCommand, format?: Format): Promise<ModelUpdateResult>;
+    edit(modeluri: string, patch: PatchOrCommand, format?: Format): Promise<ModelUpdateResult>;
 
     undo(modeluri: string): Promise<ModelUpdateResult>;
 

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -123,7 +123,7 @@ export interface ModelServerClientApiV2 {
 
     ping(): Promise<boolean>;
 
-    edit(modeluri: string, patch: PatchOrCommand, format?: Format): Promise<ModelUpdateResult>;
+    edit(modeluri: string, patchOrCommand: PatchOrCommand, format?: Format): Promise<ModelUpdateResult>;
 
     undo(modeluri: string): Promise<ModelUpdateResult>;
 

--- a/packages/modelserver-theia/src/node/theia-model-server-client-v2.ts
+++ b/packages/modelserver-theia/src/node/theia-model-server-client-v2.ts
@@ -11,17 +11,17 @@
 import {
     AddCommand,
     CompoundCommand,
+    Format,
     ModelServerClientV2,
     ModelServerCommand,
     ModelUpdateResult,
-    Operations,
+    PatchOrCommand,
     RemoveCommand,
     SetCommand,
     SubscriptionListener,
     SubscriptionOptionsV2
 } from '@eclipse-emfcloud/modelserver-client';
 import { decorate, inject, injectable, optional } from '@theia/core/shared/inversify';
-import { Operation } from 'fast-json-patch';
 import { CancellationToken } from 'vscode-jsonrpc';
 
 import { ModelServerFrontendClient, TheiaModelServerClientV2 } from '../common';
@@ -88,14 +88,11 @@ export class TheiaBackendModelServerClientV2 extends ModelServerClientV2 impleme
         this.subscribe(modeluri, undefined, options);
     }
 
-    edit(modeluri: string, patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<ModelUpdateResult> {
+    edit(modeluri: string, patchOrCommand: PatchOrCommand, format?: Format): Promise<ModelUpdateResult> {
         if (ModelServerCommand.is(patchOrCommand)) {
             return super.edit(modeluri, ensureCommandPrototype(patchOrCommand));
         }
-        if (Operations.isOperation(patchOrCommand)) {
-            return super.edit(modeluri, patchOrCommand);
-        }
-        return super.edit(modeluri, patchOrCommand);
+        return super.edit(modeluri, patchOrCommand, format);
     }
 }
 


### PR DESCRIPTION
- Add the possibility to specify Json Patches via a list of "Model Patch" objects, referencing a modelUri and a Patch. This allows edition of multi-resource models, with one Json Patch per resource.

Additional minor fixes:

- Fix a minor warning in the integration tests
- Support the optional "format" attribute in the client V2 implementation

Contributed on behalf of STMicroelectronics.

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>