### PR TITLE
#115 Ensure ModelServerCommand prototype is set

### DIFF
--- a/packages/modelserver-theia/src/node/theia-model-server-client-v2.ts
+++ b/packages/modelserver-theia/src/node/theia-model-server-client-v2.ts
@@ -116,7 +116,7 @@ function ensureCommandPrototype<T extends ModelServerCommand>(command: T): T {
         Object.setPrototypeOf(command, CompoundCommand.prototype);
         (command as CompoundCommand).commands.forEach(ensureCommandPrototype);
     }
-    return command;
+    return Object.setPrototypeOf(command, ModelServerCommand.prototype);
 }
 
 /**


### PR DESCRIPTION
Ensure ModelServerCommand prototype is explicitly set if pure commands are used (which applies to using custom commands)

Resolves #115