### PR TITLE
#179 Consistently use URI object in APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .browser_modules
 lib
 *.log
+*.log.gz
 examples/*-app/*
 !examples/*-app/package.json
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--no-cluster",
         "--root-dir=${workspaceRoot}/examples/workspace",
         "--app-project-path=${workspaceRoot}/examples/browser-app",
-        "--plugins=local-dir:${workspaceRoot}/plugins"
+        "--plugins=local-dir:${workspaceRoot}/examples/browser-app/plugins"
       ],
       "env": {
         "NODE_ENV": "development"
@@ -38,31 +38,23 @@
       "request": "launch",
       "url": "http://localhost:3000/",
       "sourceMaps": true,
-      "webRoot": "${workspaceRoot}"
+      "webRoot": "${workspaceRoot}/examples/browser-app"
     },
     {
       "type": "node",
       "request": "launch",
       "name": "Debug current test",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "--config",
-        "${workspaceFolder}/configs/.mocharc.debug.json",
-        "--file",
-        "${file}"
-      ],
+      "args": ["--config", "${workspaceFolder}/configs/.mocharc.debug.json", "--file", "${file}"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     },
     {
       "type": "node",
       "request": "launch",
       "name": "Debug all tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "--config",
-        "${workspaceFolder}/configs/.mocharc.debug.all.json"
-      ],
+      "args": ["--config", "${workspaceFolder}/configs/.mocharc.debug.all.json"],
       "env": {
         "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
       },
@@ -74,10 +66,7 @@
       "request": "launch",
       "name": "Debug all unit tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "--config",
-        "${workspaceFolder}/configs/.mocharc.debug.unit.json"
-      ],
+      "args": ["--config", "${workspaceFolder}/configs/.mocharc.debug.unit.json"],
       "env": {
         "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
       },

--- a/configs/base.eslintrc.json
+++ b/configs/base.eslintrc.json
@@ -8,7 +8,7 @@
       "jsx": true
     }
   },
-  "plugins": ["@typescript-eslint", "header", "import", "simple-import-sort", "no-null", "prettier"],
+  "plugins": ["@typescript-eslint", "header", "import", "no-null", "prettier"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",

--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -7,21 +7,12 @@
     // Best Practices
     "curly": "error",
     "eol-last": "error",
-    "eqeqeq": [
-      "error",
-      "smart"
-    ],
+    "eqeqeq": ["error", "smart"],
     "guard-for-in": "error",
     "no-caller": "error",
     "no-eval": "error",
     "no-redeclare": "off", // allow same name for Symbol and TS types
-    "no-restricted-imports": [
-      "error",
-      "..",
-      "../index",
-      "../..",
-      "../../index"
-    ],
+    "no-restricted-imports": ["error", "..", "../index", "../..", "../../index"],
     "no-sequences": "error",
     "no-throw-literal": "error",
     "no-unused-expressions": [
@@ -57,19 +48,10 @@
         "asyncArrow": "always"
       }
     ],
-    "one-var": [
-      "error",
-      "never"
-    ],
+    "one-var": ["error", "never"],
     // ECMAScript6
-    "arrow-body-style": [
-      "error",
-      "as-needed"
-    ],
-    "arrow-parens": [
-      "error",
-      "as-needed"
-    ],
+    "arrow-body-style": ["error", "as-needed"],
+    "arrow-parens": ["error", "as-needed"],
     "no-var": "error",
     "prefer-const": [
       "error",
@@ -96,10 +78,7 @@
         "avoidEscape": true
       }
     ],
-    "@typescript-eslint/semi": [
-      "error",
-      "always"
-    ],
+    "@typescript-eslint/semi": ["error", "always"],
     // eslint-plugin-header
     "header/header": [
       2,
@@ -123,14 +102,6 @@
     "import/export": "off", // we have multiple exports due to namespaces, enums and classes that share the same name
     "import/no-deprecated": "error",
     // eslint-plugin-no-null
-    "no-null/no-null": "error",
-    // simple-import/sort
-    "sort-imports": "off",
-    "import/order": "off",
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error",
-    "import/first": "error",
-    "import/newline-after-import": "error",
-    "import/no-duplicates": "error"
+    "no-null/no-null": "error"
   }
 }

--- a/examples/coffee-theia/src/node/backend-module.ts
+++ b/examples/coffee-theia/src/node/backend-module.ts
@@ -18,7 +18,7 @@ export default new ContainerModule(bind => {
 
 @injectable()
 export class SimpleLaunchOptions implements LaunchOptions {
-    baseURL = 'api/v1/';
+    baseURL = 'api/v2';
     serverPort = 8081;
     hostname = 'localhost';
     jarPath = resolve(join(__dirname, '..', '..', 'build', 'org.eclipse.emfcloud.modelserver.example-0.7.0-SNAPSHOT-standalone.jar'));

--- a/examples/dev-example/src/browser/api-test-menu.ts
+++ b/examples/dev-example/src/browser/api-test-menu.ts
@@ -524,7 +524,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
     }
 
     protected printNotification(message: ModelServerNotification, level: MessageLevel = MessageLevel.Info): Promise<void> {
-        let details: string | object = { modeluri: asString(message.modeluri), type: message.type };
+        let details: object = { modeluri: asString(message.modeluri), type: message.type };
         // Prettyprinting for update notifications in non-json format
         switch (message.type) {
             case MessageType.incrementalUpdate: {
@@ -725,8 +725,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         });
         commands.registerCommand(UnsubscribeCommand, {
             execute: () => {
-                const uri = new URI('SuperBrewer3000.coffee');
-                this.modelServerClient.unsubscribe(uri);
+                this.modelServerClient.unsubscribe(new URI('SuperBrewer3000.coffee'));
             }
         });
 

--- a/examples/dev-example/src/browser/api-test-menu.ts
+++ b/examples/dev-example/src/browser/api-test-menu.ts
@@ -8,7 +8,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-/* eslint-disable @typescript-eslint/ban-types */
 import {
     AddCommand,
     AnyObject,
@@ -35,9 +34,10 @@ import {
     MessageType as MessageLevel
 } from '@theia/core';
 import { ConfirmDialog } from '@theia/core/lib/browser';
-import URI from '@theia/core/lib/common/uri';
+import { URI as TheiaURI } from '@theia/core/lib/common/uri';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { Operation } from 'fast-json-patch';
+import URI from 'urijs';
 
 import { DevModelServerClient, UpdateTaskNameCommand } from '../common/dev-model-server-client';
 
@@ -91,29 +91,14 @@ export const GetModelCoffeeEcoreCommand: Command = {
     label: 'getModel(Coffee.ecore)'
 };
 
-export const GetModelXmiCoffeeEcoreCommand: Command = {
-    id: 'ApiTest.GetModelXmi.CoffeeEcore',
-    label: 'getModel(Coffee.ecore, xmi)'
-};
-
 export const GetModelElementByIdCoffeeEcoreCommand: Command = {
     id: 'ApiTest.GetModelElementById.CoffeeEcore',
     label: 'getModelElementById(Coffee.ecore, //@eClassifiers.2)'
 };
 
-export const GetModelElementByIdXmiCoffeeEcoreCommand: Command = {
-    id: 'ApiTest.GetModelElementByIdXmi.CoffeeEcore',
-    label: 'getModelElementById(Coffee.ecore, //@eClassifiers.2, xmi)'
-};
-
 export const GetModelElementByNameCoffeeEcoreCommand: Command = {
     id: 'ApiTest.GetModelElementByName.CoffeeEcore',
     label: 'getModelElementByName(Coffee.ecore, Machine)'
-};
-
-export const GetModelElementByNameXmiCoffeeEcoreCommand: Command = {
-    id: 'ApiTest.GetModelElementByNameXmi.CoffeeEcore',
-    label: 'getModelElementByName(Coffee.ecore, Machine, xmi)'
 };
 
 export const EditCompoundCoffeeEcoreCommand: Command = {
@@ -181,11 +166,6 @@ export const SubscribeAndKeepAliveCommand: Command = {
     label: 'subscribeAndKeepAlive(Coffee.ecore, 60000)'
 };
 
-export const SubscribeAndKeepAliveXmiCommand: Command = {
-    id: 'ApiTest.SubscribeAndKeepAliveXmi',
-    label: 'subscribeAndKeepAlive(Coffee.ecore, 60000, xmi)'
-};
-
 export const UnsubscribeKeepAliveCommand: Command = {
     id: 'ApiTest.UnsubscribeKeepAlive',
     label: 'unsubscribe(Coffee.ecore)'
@@ -195,6 +175,11 @@ export const UnsubscribeKeepAliveCommand: Command = {
 export const GetModelCommand: Command = {
     id: 'ApiTest.GetModel.SuperBrewer3000',
     label: 'getModel(SuperBrewer3000.coffee)'
+};
+
+export const GetModelCoffeeCommand: Command = {
+    id: 'ApiTest.GetModelCoffee.SuperBrewer3000',
+    label: 'getModel(SuperBrewer3000.coffee, coffee)'
 };
 
 export const GetModelElementByIdCommand: Command = {
@@ -207,9 +192,9 @@ export const GetModelElementByNameCommand: Command = {
     label: 'getModelElementByName(SuperBrewer3000.coffee, BrewingFlow)'
 };
 
-export const PatchCommand: Command = {
+export const UpdateModelCommand: Command = {
     id: 'ApiTest.Patch.SuperBrewer3000',
-    label: 'patch(SuperBrewer3000.coffee)'
+    label: 'updateModel(SuperBrewer3000.coffee)'
 };
 
 export const EditSetCommand: Command = {
@@ -311,6 +296,21 @@ export const EditRemoveSuperBrewer3000JsonCommand: Command = {
 export const UpdateTaskNameSuperBrewer3000JsonCustomCommand: Command = {
     id: 'ApiTest.UpdateTaskName.SuperBrewer3000Json',
     label: "edit(SuperBrewer3000.json,{type:updateTaskName},'Coffee')"
+};
+
+export const EditReplaceSuperBrewer3000JsonPatch: Command = {
+    id: 'ApiTest.EditReplacePath.SuperBrewer3000',
+    label: 'patch(SuperBrewer3000.json,{type:set})'
+};
+
+export const EditAddSuperBrewer3000JsonPatch: Command = {
+    id: 'ApiTest.EditAddPatch.SuperBrewer3000',
+    label: 'patch(SuperBrewer3000.json,{type:add})'
+};
+
+export const EditRemoveSuperBrewer3000JsonPatch: Command = {
+    id: 'ApiTest.EditRemovePatch.SuperBrewer3000',
+    label: 'patch(SuperBrewer3000.json,{type:remove})'
 };
 
 export const UndoSuperBrewer3000JsonCommand: Command = {
@@ -430,13 +430,13 @@ export const CUSTOM_TEST_MENU = [...MAIN_MENU_BAR, '9_4_API_TEST_MENU_CUSTOM'];
 export const CUSTOM_TEST_COUNTER_SECTION = [...CUSTOM_TEST_MENU, '1_COUNTER'];
 
 const superBrewer3000JsonPatch = {
-    eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine',
+    $type: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine',
     children: [
         {
-            eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit'
+            $type: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit'
         },
         {
-            eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit',
+            $type: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit',
             processor: {
                 clockSpeed: 50,
                 numberOfCores: 20,
@@ -454,10 +454,10 @@ const superBrewer3000JsonPatch = {
         {
             nodes: [
                 {
-                    eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
+                    $type: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
                     name: 'PreHeat',
                     component: {
-                        eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit',
+                        $type: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit',
                         $ref: '//@children.0'
                     }
                 }
@@ -468,21 +468,14 @@ const superBrewer3000JsonPatch = {
 
 @injectable()
 export class ApiTestMenuContribution implements MenuContribution, CommandContribution {
-    @inject(MessageService) protected readonly messageService: MessageService;
-    @inject(DevModelServerClient) protected readonly modelServerClient: DevModelServerClient;
-
-    @inject(ModelServerSubscriptionService) protected readonly modelServerSubscriptionService: ModelServerSubscriptionService;
-    @inject(DiagnosticManager) protected readonly diagnosticManager: DiagnosticManager;
-
-    private workspaceUri: string;
-
-    constructor(@inject(WorkspaceService) protected readonly workspaceService: WorkspaceService) {
-        workspaceService.onWorkspaceChanged(workspace => {
-            if (workspace[0] && workspace[0].resource) {
-                this.workspaceUri = workspace[0].resource.toString().replace('file://', 'file:');
-            }
-        });
-    }
+    @inject(DevModelServerClient)
+    protected readonly modelServerClient: DevModelServerClient;
+    @inject(DiagnosticManager)
+    protected readonly diagnosticManager: DiagnosticManager;
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+    @inject(ModelServerSubscriptionService)
+    protected readonly modelServerSubscriptionService: ModelServerSubscriptionService;
 
     @postConstruct()
     init(): void {
@@ -521,7 +514,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
     ): Promise<void> {
         const messageParams: MessageParams = {
             message: `Received response for '${request}' request`,
-            details: response,
+            details: asString(response),
             sender: 'Modelserver',
             detailsLabel: 'Show response',
             detailsTitle: `Response for ${request}`,
@@ -531,26 +524,37 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
     }
 
     protected printNotification(message: ModelServerNotification, level: MessageLevel = MessageLevel.Info): Promise<void> {
-        let details: string | object = message;
+        let details: string | object = { modeluri: asString(message.modeluri), type: message.type };
         // Prettyprinting for update notifications in non-json format
-        if (message.type === MessageType.incrementalUpdate) {
-            const result = (message as IncrementalUpdateNotification).result;
-            if (typeof result === 'string') {
-                details = JSON.stringify({ modelUri: message.modelUri, type: message.type, result: 'XMI (see output below)' });
-                details += '\n' + result;
+        switch (message.type) {
+            case MessageType.incrementalUpdate: {
+                const result = (message as IncrementalUpdateNotification).result;
+                if (typeof result === 'string') {
+                    details = { ...details, result: JSON.parse(result) };
+                }
+                break;
             }
-        } else if (message.type === MessageType.fullUpdate) {
-            const model = (message as FullUpdateNotification).model;
-            if (typeof model === 'string') {
-                details = JSON.stringify({ modelUri: message.modelUri, type: message.type, model: 'XMI (see output below)' });
-                details += '\n' + model;
+            case MessageType.fullUpdate: {
+                const model = (message as FullUpdateNotification).model;
+                if (typeof model === 'string') {
+                    details = { ...details, model: JSON.parse(model) };
+                } else {
+                    details = { ...details, model };
+                }
+                break;
+            }
+            default: {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { modeluri, type, ...notificationDetails } = message;
+                details = { ...details, ...notificationDetails };
+                break;
             }
         }
 
         const messageParams: MessageParams = {
             message: `'${message.type}' notification received`,
-            sender: message.modelUri,
-            details,
+            sender: message.modeluri.toString(),
+            details: JSON.stringify(details, undefined, 2),
             detailsLabel: 'Show notification',
             detailsTitle: `Notification details [${message.type}]`,
             level
@@ -586,7 +590,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         });
         commands.registerCommand(GetTypeSchemaCommand, {
             execute: () => {
-                this.modelServerClient.getTypeSchema('Coffee.ecore').then(result => this.printResponse('getTypeSchema', result));
+                this.modelServerClient.getTypeSchema(new URI('Coffee.ecore')).then(result => this.printResponse('getTypeSchema', result));
             }
         });
         commands.registerCommand(GetUiSchemaCommand, {
@@ -598,20 +602,25 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         /* SuperBrewer3000.coffee commands */
         commands.registerCommand(GetModelCommand, {
             execute: () => {
-                this.modelServerClient.get('SuperBrewer3000.coffee').then(result => this.printResponse('get', result));
+                this.modelServerClient.get(new URI('SuperBrewer3000.coffee')).then(result => this.printResponse('get', result));
+            }
+        });
+        commands.registerCommand(GetModelCoffeeCommand, {
+            execute: () => {
+                this.modelServerClient.get(new URI('SuperBrewer3000.coffee'), 'coffee').then(result => this.printResponse('get', result));
             }
         });
         commands.registerCommand(GetModelElementByIdCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getElementById('SuperBrewer3000.coffee', '//@workflows.0')
+                    .getElementById(new URI('SuperBrewer3000.coffee'), '//@workflows.0')
                     .then(result => this.printResponse('getElementById', result));
             }
         });
         commands.registerCommand(GetModelElementByNameCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getElementByName('SuperBrewer3000.coffee', 'BrewingFlow')
+                    .getElementByName(new URI('SuperBrewer3000.coffee'), 'BrewingFlow')
                     .then(result => this.printResponse('getElementByName', result));
             }
         });
@@ -619,13 +628,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
-                    $ref: `${this.workspaceUri}/SuperBrewer3000.coffee#//@workflows.0/@nodes.0`
+                    $ref: URI.build({ path: 'SuperBrewer3000.coffee', fragment: '//@workflows.0/@nodes.0' })
                 };
                 const feature = 'name';
                 const changedValues = ['Auto Brew'];
                 const setCommand = new SetCommand(owner, feature, changedValues);
                 this.modelServerClient
-                    .edit('SuperBrewer3000.coffee', setCommand)
+                    .edit(new URI('SuperBrewer3000.coffee'), setCommand)
                     .then(result => this.printResponse('edit SetCommand', result));
             }
         });
@@ -633,13 +642,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow',
-                    $ref: `${this.workspaceUri}/SuperBrewer3000.coffee#//@workflows.0`
+                    $ref: URI.build({ path: 'SuperBrewer3000.coffee', fragment: '//@workflows.0' })
                 };
                 const feature = 'nodes';
                 const indices = [0];
                 const removeCommand = new RemoveCommand(owner, feature, indices);
                 this.modelServerClient
-                    .edit('SuperBrewer3000.coffee', removeCommand)
+                    .edit(new URI('SuperBrewer3000.coffee'), removeCommand)
                     .then(result => this.printResponse('edit RemoveCommand', result));
             }
         });
@@ -647,52 +656,52 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow',
-                    $ref: `${this.workspaceUri}/SuperBrewer3000.coffee#//@workflows.0`
+                    $ref: URI.build({ path: 'SuperBrewer3000.coffee', fragment: '//@workflows.0' })
                 };
                 const feature = 'nodes';
                 const toAdd = [{ eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask' }];
                 const addCommand = new AddCommand(owner, feature, toAdd);
                 this.modelServerClient
-                    .edit('SuperBrewer3000.coffee', addCommand)
+                    .edit(new URI('SuperBrewer3000.coffee'), addCommand)
                     .then(result => this.printResponse('edit AddCommand', result));
             }
         });
-        commands.registerCommand(PatchCommand, {
+        commands.registerCommand(UpdateModelCommand, {
             execute: () => {
                 this.modelServerClient
-                    .update('SuperBrewer3000.coffee', superBrewer3000JsonPatch)
+                    .update(new URI('SuperBrewer3000.coffee'), superBrewer3000JsonPatch)
                     .then(result => this.printResponse('update', result));
             }
         });
         commands.registerCommand(UndoCommand, {
             execute: () => {
-                this.modelServerClient.undo('SuperBrewer3000.coffee').then(result => this.printResponse('undo', result));
+                this.modelServerClient.undo(new URI('SuperBrewer3000.coffee')).then(result => this.printResponse('undo', result));
             }
         });
         commands.registerCommand(RedoCommand, {
             execute: () => {
-                this.modelServerClient.redo('SuperBrewer3000.coffee').then(result => this.printResponse('redo', result));
+                this.modelServerClient.redo(new URI('SuperBrewer3000.coffee')).then(result => this.printResponse('redo', result));
             }
         });
         commands.registerCommand(SaveCommand, {
             execute: () => {
-                this.modelServerClient.save('SuperBrewer3000.coffee').then(result => this.printResponse('save', result));
+                this.modelServerClient.save(new URI('SuperBrewer3000.coffee')).then(result => this.printResponse('save', result));
             }
         });
         commands.registerCommand(CloseCommand, {
             execute: () => {
-                this.modelServerClient.close('SuperBrewer3000.coffee').then(result => this.printResponse('close', result));
+                this.modelServerClient.close(new URI('SuperBrewer3000.coffee')).then(result => this.printResponse('close', result));
             }
         });
         commands.registerCommand(ValidationCommand, {
             execute: () => {
-                this.modelServerClient.validate('SuperBrewer3000.coffee').then(result => this.printResponse('validate', result));
+                this.modelServerClient.validate(new URI('SuperBrewer3000.coffee')).then(result => this.printResponse('validate', result));
             }
         });
         commands.registerCommand(ValidationMarkersCommand, {
             execute: () => {
-                this.modelServerClient.validate('SuperBrewer3000.coffee').then(result => {
-                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new URI('SuperBrewer3000.coffee'), result);
+                this.modelServerClient.validate(new URI('SuperBrewer3000.coffee')).then(result => {
+                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new TheiaURI('SuperBrewer3000.coffee'), result);
                     this.messageService.info(message);
                 });
             }
@@ -700,70 +709,54 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationConstraintsCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getValidationConstraints('SuperBrewer3000.coffee')
+                    .getValidationConstraints(new URI('SuperBrewer3000.coffee'))
                     .then(result => this.printResponse('getValidationConstraints', result));
             }
         });
         commands.registerCommand(SubscribeCommand, {
             execute: () => {
-                this.modelServerClient.subscribe('SuperBrewer3000.coffee');
+                this.modelServerClient.subscribe(new URI('SuperBrewer3000.coffee'), undefined, { errorWhenUnsuccessful: true });
             }
         });
         commands.registerCommand(SubscribeWithValidationCommand, {
             execute: () => {
-                this.modelServerClient.subscribe('SuperBrewer3000.coffee', { livevalidation: true });
+                this.modelServerClient.subscribe(new URI('SuperBrewer3000.coffee'), undefined, { livevalidation: true });
             }
         });
         commands.registerCommand(UnsubscribeCommand, {
             execute: () => {
-                this.modelServerClient.unsubscribe('SuperBrewer3000.coffee');
+                const uri = new URI('SuperBrewer3000.coffee');
+                this.modelServerClient.unsubscribe(uri);
             }
         });
 
         /* Coffee.ecore commands */
         commands.registerCommand(GetModelCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.get<AnyObject>('Coffee.ecore', AnyObject.is).then(result => this.printResponse('get', result));
-            }
-        });
-        commands.registerCommand(GetModelXmiCoffeeEcoreCommand, {
-            execute: () => {
-                this.modelServerClient.get('Coffee.ecore', 'xmi').then(result => this.printResponse('get in xmi format', result));
+                this.modelServerClient
+                    .get<AnyObject>(new URI('Coffee.ecore'), AnyObject.is)
+                    .then(result => this.printResponse('get', result));
             }
         });
         commands.registerCommand(GetModelElementByIdCoffeeEcoreCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getElementById('Coffee.ecore', '//@eClassifiers.2')
+                    .getElementById(new URI('Coffee.ecore'), '//@eClassifiers.2')
                     .then(result => this.printResponse('getElementById', result));
-            }
-        });
-        commands.registerCommand(GetModelElementByIdXmiCoffeeEcoreCommand, {
-            execute: () => {
-                this.modelServerClient
-                    .getElementById('Coffee.ecore', '//@eClassifiers.2', 'xmi')
-                    .then(result => this.printResponse('getElementById in xmi format', result));
             }
         });
         commands.registerCommand(GetModelElementByNameCoffeeEcoreCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getElementByName('Coffee.ecore', 'Machine')
+                    .getElementByName(new URI('Coffee.ecore'), 'Machine')
                     .then(result => this.printResponse('getElementByName', result));
-            }
-        });
-        commands.registerCommand(GetModelElementByNameXmiCoffeeEcoreCommand, {
-            execute: () => {
-                this.modelServerClient
-                    .getElementByName('Coffee.ecore', 'Machine', 'xmi')
-                    .then(result => this.printResponse('getElementByName in xmi format', result));
             }
         });
         commands.registerCommand(EditCompoundCoffeeEcoreCommand, {
             execute: () => {
                 const ownerA = {
                     eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EClass',
-                    $ref: `${this.workspaceUri}/Coffee.ecore#//@eClassifiers.2`
+                    $ref: URI.build({ path: 'Coffee.ecore', fragment: '//@eClassifiers.2' })
                 };
                 const featureA = 'name';
                 const changedValuesA = ['ControlUnitNew'];
@@ -771,7 +764,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
 
                 const ownerB = {
                     eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EClass',
-                    $ref: `${this.workspaceUri}/Coffee.ecore#//@eClassifiers.5`
+                    $ref: URI.build({ path: 'Coffee.ecore', fragment: '//@eClassifiers.5' })
                 };
                 const featureB = 'name';
                 const changedValuesB = ['WaterTankNew'];
@@ -780,7 +773,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
                 const compoundCommand = new CompoundCommand([setCommandA, setCommandB]);
 
                 this.modelServerClient
-                    .edit('Coffee.ecore', compoundCommand)
+                    .edit(new URI('Coffee.ecore'), compoundCommand)
                     .then(result => this.printResponse('edit CompoundCommand', result));
             }
         });
@@ -788,67 +781,71 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EClass',
-                    $ref: `${this.workspaceUri}/Coffee.ecore#//@eClassifiers.2`
+                    $ref: URI.build({ path: 'Coffee.ecore', fragment: '//@eClassifiers.2' })
                 };
                 const feature = 'name';
                 const changedValues = ['ControlUnitNew'];
                 const setCommand = new SetCommand(owner, feature, changedValues);
-                this.modelServerClient.edit('Coffee.ecore', setCommand).then(result => this.printResponse('edit SetCommand', result));
+                this.modelServerClient
+                    .edit(new URI('Coffee.ecore'), setCommand)
+                    .then(result => this.printResponse('edit SetCommand', result));
             }
         });
         commands.registerCommand(EditRemoveCoffeeEcoreCommand, {
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EPackage',
-                    $ref: `${this.workspaceUri}/Coffee.ecore#/`
+                    $ref: URI.build({ path: 'Coffee.ecore', fragment: '/' })
                 };
                 const feature = 'eClassifiers';
                 const indices = [5];
                 const removeCommand = new RemoveCommand(owner, feature, indices);
-                this.modelServerClient.edit('Coffee.ecore', removeCommand).then(result => this.printResponse('edit RemoveCommand', result));
+                this.modelServerClient
+                    .edit(new URI('Coffee.ecore'), removeCommand)
+                    .then(result => this.printResponse('edit RemoveCommand', result));
             }
         });
         commands.registerCommand(EditAddCoffeeEcoreCommand, {
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EPackage',
-                    $ref: `${this.workspaceUri}/Coffee.ecore#/`
+                    $ref: URI.build({ path: 'Coffee.ecore', fragment: '/' })
                 };
                 const feature = 'eClassifiers';
                 const toAdd = [{ eClass: 'http://www.eclipse.org/emf/2002/Ecore#//EClass', name: 'NewEClassifier' }];
                 const addCommand = new AddCommand(owner, feature, toAdd);
-                this.modelServerClient.edit('Coffee.ecore', addCommand).then(result => this.printResponse('edit', result));
+                this.modelServerClient.edit(new URI('Coffee.ecore'), addCommand).then(result => this.printResponse('edit', result));
             }
         });
         commands.registerCommand(UndoCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.undo('Coffee.ecore').then(result => this.printResponse('undo', result));
+                this.modelServerClient.undo(new URI('Coffee.ecore')).then(result => this.printResponse('undo', result));
             }
         });
         commands.registerCommand(RedoCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.redo('Coffee.ecore').then(result => this.printResponse('redo', result));
+                this.modelServerClient.redo(new URI('Coffee.ecore')).then(result => this.printResponse('redo', result));
             }
         });
         commands.registerCommand(SaveCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.save('Coffee.ecore').then(result => this.printResponse('save', result));
+                this.modelServerClient.save(new URI('Coffee.ecore')).then(result => this.printResponse('save', result));
             }
         });
         commands.registerCommand(CloseCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.close('Coffee.ecore').then(result => this.printResponse('close', result));
+                this.modelServerClient.close(new URI('Coffee.ecore')).then(result => this.printResponse('close', result));
             }
         });
         commands.registerCommand(ValidationCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.validate('Coffee.ecore').then(result => this.printResponse('validate', result));
+                this.modelServerClient.validate(new URI('Coffee.ecore')).then(result => this.printResponse('validate', result));
             }
         });
         commands.registerCommand(ValidationMarkersCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.validate('Coffee.ecore').then(result => {
-                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new URI('Coffee.ecore'), result);
+                this.modelServerClient.validate(new URI('Coffee.ecore')).then(result => {
+                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new TheiaURI('Coffee.ecore'), result);
                     this.messageService.info(message);
                 });
             }
@@ -856,48 +853,43 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationConstraintsCoffeeEcoreCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getValidationConstraints('Coffee.ecore')
+                    .getValidationConstraints(new URI('Coffee.ecore'))
                     .then(result => this.printResponse('getValidationConstraints', result));
             }
         });
         commands.registerCommand(SubscribeWithValidationCoffeeEcoreCommand, {
             execute: () => {
-                this.modelServerClient.subscribe('Coffee.ecore', { livevalidation: true });
+                this.modelServerClient.subscribe(new URI('Coffee.ecore'), undefined, { livevalidation: true });
             }
         });
         commands.registerCommand(SubscribeAndKeepAliveCommand, {
             execute: () => {
-                this.modelServerClient.subscribe('Coffee.ecore', { timeout: 60000 });
-            }
-        });
-        commands.registerCommand(SubscribeAndKeepAliveXmiCommand, {
-            execute: () => {
-                this.modelServerClient.subscribe('Coffee.ecore', { livevalidation: true, timeout: 60000, format: 'xmi' });
+                this.modelServerClient.subscribe(new URI('Coffee.ecore'), undefined, { timeout: 60000 });
             }
         });
         commands.registerCommand(UnsubscribeKeepAliveCommand, {
             execute: () => {
-                this.modelServerClient.unsubscribe('Coffee.ecore');
+                this.modelServerClient.unsubscribe(new URI('Coffee.ecore'));
             }
         });
 
         /* SuperBrewer3000.json commands */
         commands.registerCommand(GetModelSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.get('SuperBrewer3000.json').then(result => this.printResponse('get', result));
+                this.modelServerClient.get(new URI('SuperBrewer3000.json')).then(result => this.printResponse('get', result));
             }
         });
         commands.registerCommand(GetModelElementByIdSuperBrewer3000JsonCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getElementById('SuperBrewer3000.json', '//@workflows.0')
+                    .getElementById(new URI('SuperBrewer3000.json'), '//@workflows.0')
                     .then(result => this.printResponse('getElementById', result));
             }
         });
         commands.registerCommand(GetModelElementByNameSuperBrewer3000JsonCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getElementByName('SuperBrewer3000.json', 'Super Brewer 3000')
+                    .getElementByName(new URI('SuperBrewer3000.json'), 'Super Brewer 3000')
                     .then(result => this.printResponse('getElementByName', result));
             }
         });
@@ -905,13 +897,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
-                    $ref: `${this.workspaceUri}/SuperBrewer3000.json#//@workflows.0/@nodes.0`
+                    $ref: URI.build({ path: 'SuperBrewer3000.json', fragment: '//@workflows.0/@nodes.0' })
                 };
                 const feature = 'name';
                 const changedValues = ['Auto Brew'];
                 const setCommand = new SetCommand(owner, feature, changedValues);
                 this.modelServerClient
-                    .edit('SuperBrewer3000.json', setCommand)
+                    .edit(new URI('SuperBrewer3000.json'), setCommand)
                     .then(result => this.printResponse('edit SetCommand', result));
             }
         });
@@ -919,13 +911,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow',
-                    $ref: `${this.workspaceUri}/SuperBrewer3000.json#//@workflows.0`
+                    $ref: URI.build({ path: 'SuperBrewer3000.json', fragment: '//@workflows.0' })
                 };
                 const feature = 'nodes';
                 const indices = [0];
                 const removeCommand = new RemoveCommand(owner, feature, indices);
                 this.modelServerClient
-                    .edit('SuperBrewer3000.json', removeCommand)
+                    .edit(new URI('SuperBrewer3000.json'), removeCommand)
                     .then(result => this.printResponse('edit RemoveCommand', result));
             }
         });
@@ -933,13 +925,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const owner = {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow',
-                    $ref: `${this.workspaceUri}/SuperBrewer3000.json#//@workflows.0`
+                    $ref: URI.build({ path: 'SuperBrewer3000.json', fragment: '//@workflows.0' })
                 };
                 const feature = 'nodes';
                 const toAdd = [{ eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask' }];
                 const addCommand = new AddCommand(owner, feature, toAdd);
                 this.modelServerClient
-                    .edit('SuperBrewer3000.json', addCommand)
+                    .edit(new URI('SuperBrewer3000.json'), addCommand)
                     .then(result => this.printResponse('edit AddCommand', result));
             }
         });
@@ -947,39 +939,74 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
             execute: () => {
                 const updateTaskName = new UpdateTaskNameCommand('Coffee');
                 this.modelServerClient
-                    .edit('SuperBrewer3000.json', updateTaskName)
+                    .edit(new URI('SuperBrewer3000.json'), updateTaskName)
                     .then(result => this.printResponse('edit CustomCommand', result));
+            }
+        });
+        commands.registerCommand(EditAddSuperBrewer3000JsonPatch, {
+            execute: () => {
+                const addPatch: Operation = {
+                    op: 'add',
+                    path: URI.build({ path: 'SuperBrewer3000.json', fragment: '//@workflows.0/nodes' }),
+                    value: { $type: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask' }
+                };
+                this.modelServerClient
+                    .edit(new URI('SuperBrewer3000.json'), addPatch)
+                    .then(result => this.printResponse('edit add patch', result));
+            }
+        });
+        commands.registerCommand(EditRemoveSuperBrewer3000JsonPatch, {
+            execute: () => {
+                const removePatch: Operation = {
+                    op: 'remove',
+                    path: URI.build({ path: 'SuperBrewer3000.json', fragment: '//@workflows.0/@nodes.0' })
+                };
+                this.modelServerClient
+                    .edit(new URI('SuperBrewer3000.json'), removePatch)
+                    .then(result => this.printResponse('edit remove patch', result));
+            }
+        });
+        commands.registerCommand(EditReplaceSuperBrewer3000JsonPatch, {
+            execute: () => {
+                const replacePatch: Operation = {
+                    op: 'replace',
+                    path: URI.build({ path: 'SuperBrewer3000.json', fragment: '//@workflows.0/@nodes.0/name' }),
+                    value: 'Auto Brew'
+                };
+                this.modelServerClient
+                    .edit(new URI('SuperBrewer3000.json'), replacePatch)
+                    .then(result => this.printResponse('edit replace patch', result));
             }
         });
         commands.registerCommand(UndoSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.undo('SuperBrewer3000.json').then(result => this.printResponse('undo', result));
+                this.modelServerClient.undo(new URI('SuperBrewer3000.json')).then(result => this.printResponse('undo', result));
             }
         });
         commands.registerCommand(RedoSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.redo('SuperBrewer3000.json').then(result => this.printResponse('redo', result));
+                this.modelServerClient.redo(new URI('SuperBrewer3000.json')).then(result => this.printResponse('redo', result));
             }
         });
         commands.registerCommand(SaveSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.save('SuperBrewer3000.json').then(result => this.printResponse('save', result));
+                this.modelServerClient.save(new URI('SuperBrewer3000.json')).then(result => this.printResponse('save', result));
             }
         });
         commands.registerCommand(CloseSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.close('SuperBrewer3000.json').then(result => this.printResponse('close', result));
+                this.modelServerClient.close(new URI('SuperBrewer3000.json')).then(result => this.printResponse('close', result));
             }
         });
         commands.registerCommand(ValidationSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.validate('SuperBrewer3000.json').then(result => this.printResponse('validate', result));
+                this.modelServerClient.validate(new URI('SuperBrewer3000.json')).then(result => this.printResponse('validate', result));
             }
         });
         commands.registerCommand(ValidationMarkersSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.validate('SuperBrewer3000.json').then(result => {
-                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new URI('SuperBrewer3000.json'), result);
+                this.modelServerClient.validate(new URI('SuperBrewer3000.json')).then(result => {
+                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new TheiaURI('SuperBrewer3000.json'), result);
                     this.messageService.info(message);
                 });
             }
@@ -987,28 +1014,28 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationConstraintsSuperBrewer3000JsonCommand, {
             execute: () => {
                 this.modelServerClient
-                    .getValidationConstraints('SuperBrewer3000.json')
+                    .getValidationConstraints(new URI('SuperBrewer3000.json'))
                     .then(result => this.printResponse('getValidationConstraints', result));
             }
         });
         commands.registerCommand(SubscribeWithValidationSuperBrewer3000JsonCommand, {
             execute: () => {
-                this.modelServerClient.subscribe('SuperBrewer3000.json', { livevalidation: true });
+                this.modelServerClient.subscribe(new URI('SuperBrewer3000.json'), undefined, { livevalidation: true });
             }
         });
         commands.registerCommand(SubscribeWithTimeoutCommand, {
             execute: () => {
-                this.modelServerClient.subscribe('SuperBrewer3000.json', { timeout: 10000 });
+                this.modelServerClient.subscribe(new URI('SuperBrewer3000.json'), undefined, { timeout: 10000 });
             }
         });
         commands.registerCommand(KeepSubscriptionAliveCommand, {
             execute: () => {
-                this.modelServerClient.send('SuperBrewer3000.json', { type: MessageType.keepAlive, data: undefined });
+                this.modelServerClient.send(new URI('SuperBrewer3000.json'), { type: MessageType.keepAlive, data: undefined });
             }
         });
         commands.registerCommand(UnsubscribeTimeoutCommand, {
             execute: () => {
-                this.modelServerClient.unsubscribe('SuperBrewer3000.json');
+                this.modelServerClient.unsubscribe(new URI('SuperBrewer3000.json'));
             }
         });
 
@@ -1051,11 +1078,8 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerSubmenu(COFFEE_TEST_MENU, 'Coffee.ecore');
 
         menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelCoffeeEcoreCommand.id, order: 'a' });
-        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelXmiCoffeeEcoreCommand.id, order: 'b' });
-        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelElementByIdCoffeeEcoreCommand.id, order: 'c' });
-        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelElementByIdXmiCoffeeEcoreCommand.id, order: 'd' });
-        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelElementByNameCoffeeEcoreCommand.id, order: 'e' });
-        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelElementByNameXmiCoffeeEcoreCommand.id, order: 'f' });
+        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelElementByIdCoffeeEcoreCommand.id, order: 'b' });
+        menus.registerMenuAction(COFFEE_GET_SECTION, { commandId: GetModelElementByNameCoffeeEcoreCommand.id, order: 'c' });
 
         menus.registerMenuAction(COFFEE_EDIT_SECTION, { commandId: EditCompoundCoffeeEcoreCommand.id });
         menus.registerMenuAction(COFFEE_EDIT_SECTION, { commandId: EditSetCoffeeEcoreCommand.id });
@@ -1073,20 +1097,20 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
 
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeAndKeepAliveCommand.id });
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeWithValidationCoffeeEcoreCommand.id });
-        menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: SubscribeAndKeepAliveXmiCommand.id });
         menus.registerMenuAction(COFFEE_WEBSOCKET_SECTION, { commandId: UnsubscribeKeepAliveCommand.id });
 
         /* SuperBrewer3000.coffee */
         menus.registerSubmenu(SUPERBREWER_TEST_MENU, 'SuperBrewer3000.coffee');
 
         menus.registerMenuAction(SUPERBREWER_GET_SECTION, { commandId: GetModelCommand.id, order: 'a' });
-        menus.registerMenuAction(SUPERBREWER_GET_SECTION, { commandId: GetModelElementByIdCommand.id, order: 'b' });
-        menus.registerMenuAction(SUPERBREWER_GET_SECTION, { commandId: GetModelElementByNameCommand.id, order: 'c' });
+        menus.registerMenuAction(SUPERBREWER_GET_SECTION, { commandId: GetModelCoffeeCommand.id, order: 'b' });
+        menus.registerMenuAction(SUPERBREWER_GET_SECTION, { commandId: GetModelElementByIdCommand.id, order: 'c' });
+        menus.registerMenuAction(SUPERBREWER_GET_SECTION, { commandId: GetModelElementByNameCommand.id, order: 'd' });
 
         menus.registerMenuAction(SUPERBREWER_EDIT_SECTION, { commandId: EditSetCommand.id });
         menus.registerMenuAction(SUPERBREWER_EDIT_SECTION, { commandId: EditRemoveCommand.id });
         menus.registerMenuAction(SUPERBREWER_EDIT_SECTION, { commandId: EditAddCommand.id });
-        menus.registerMenuAction(SUPERBREWER_EDIT_SECTION, { commandId: PatchCommand.id });
+        menus.registerMenuAction(SUPERBREWER_EDIT_SECTION, { commandId: UpdateModelCommand.id });
 
         menus.registerMenuAction(SUPERBREWER_SAVE_SECTION, { commandId: SaveCommand.id });
         menus.registerMenuAction(SUPERBREWER_SAVE_SECTION, { commandId: UndoCommand.id });
@@ -1115,6 +1139,9 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         menus.registerMenuAction(SUPERBREWER_JSON_EDIT_SECTION, { commandId: EditRemoveSuperBrewer3000JsonCommand.id });
         menus.registerMenuAction(SUPERBREWER_JSON_EDIT_SECTION, { commandId: EditAddSuperBrewer3000JsonCommand.id });
         menus.registerMenuAction(SUPERBREWER_JSON_EDIT_SECTION, { commandId: UpdateTaskNameSuperBrewer3000JsonCustomCommand.id });
+        menus.registerMenuAction(SUPERBREWER_JSON_EDIT_SECTION, { commandId: EditReplaceSuperBrewer3000JsonPatch.id });
+        menus.registerMenuAction(SUPERBREWER_JSON_EDIT_SECTION, { commandId: EditRemoveSuperBrewer3000JsonPatch.id });
+        menus.registerMenuAction(SUPERBREWER_JSON_EDIT_SECTION, { commandId: EditAddSuperBrewer3000JsonPatch.id });
 
         menus.registerMenuAction(SUPERBREWER_JSON_SAVE_SECTION, { commandId: SaveSuperBrewer3000JsonCommand.id });
         menus.registerMenuAction(SUPERBREWER_JSON_SAVE_SECTION, { commandId: UndoSuperBrewer3000JsonCommand.id });
@@ -1157,13 +1184,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
 /**
  * Create the markers in the problem view
  * @param diagnosticManager the diagnostic manager
- * @param modelURI the concerned model URI
+ * @param theiaURI the concerned model URI
  * @param response the validation response
  * @returns the message to log
  */
-function createMarkersFromDiagnostic(diagnosticManager: DiagnosticManager, modelURI: URI, diagnostic: Diagnostic): string {
+function createMarkersFromDiagnostic(diagnosticManager: DiagnosticManager, theiaURI: TheiaURI, diagnostic: Diagnostic): string {
     // print markers in Problems view
-    diagnosticManager.setDiagnostic(modelURI, diagnostic);
+    diagnosticManager.setDiagnostic(theiaURI, diagnostic);
     const level = Diagnostic.getSeverityLabel(diagnostic);
     if (level === 'OK') {
         return `Validation is ${level}. There should be no new marker in Problems view.`;

--- a/examples/dev-example/src/browser/frontend-module.ts
+++ b/examples/dev-example/src/browser/frontend-module.ts
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-import { TheiaModelServerClient } from '@eclipse-emfcloud/modelserver-theia';
+import { TheiaModelServerClientV2 } from '@eclipse-emfcloud/modelserver-theia';
 import { CommandContribution, MenuContribution } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 
@@ -19,5 +19,5 @@ export default new ContainerModule(bind => {
     bind(ApiTestMenuContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ApiTestMenuContribution);
     bind(MenuContribution).toService(ApiTestMenuContribution);
-    bind(DevModelServerClient).toService(TheiaModelServerClient);
+    bind(DevModelServerClient).toService(TheiaModelServerClientV2);
 });

--- a/examples/dev-example/src/common/dev-model-server-client.ts
+++ b/examples/dev-example/src/common/dev-model-server-client.ts
@@ -9,10 +9,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import { AnyObject, ModelServerCommand } from '@eclipse-emfcloud/modelserver-client';
-import { TheiaModelServerClient } from '@eclipse-emfcloud/modelserver-theia';
+import { TheiaModelServerClientV2 } from '@eclipse-emfcloud/modelserver-theia';
 
 export const DevModelServerClient = Symbol('DevModelServerClient');
-export interface DevModelServerClient extends TheiaModelServerClient {
+export interface DevModelServerClient extends TheiaModelServerClientV2 {
     counter(operation: 'add' | 'subtract' | undefined, delta: number | undefined): Promise<AnyObject>;
 }
 

--- a/examples/dev-example/src/node/backend-module.ts
+++ b/examples/dev-example/src/node/backend-module.ts
@@ -8,11 +8,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-import { TheiaModelServerClient } from '@eclipse-emfcloud/modelserver-theia';
+import { TheiaModelServerClientV2 } from '@eclipse-emfcloud/modelserver-theia';
 import { ContainerModule } from '@theia/core/shared/inversify';
 
 import { CustomDevModelServerClient } from './model-server-client';
 
 export default new ContainerModule((_bind, _unbind, _isBound, rebind) => {
-    rebind(TheiaModelServerClient).to(CustomDevModelServerClient).inSingletonScope();
+    rebind(TheiaModelServerClientV2).to(CustomDevModelServerClient).inSingletonScope();
 });

--- a/examples/dev-example/src/node/model-server-client.ts
+++ b/examples/dev-example/src/node/model-server-client.ts
@@ -35,8 +35,8 @@ export class CustomDevModelServerClient extends TheiaBackendModelServerClientV2 
     private setKeepAliveInterval(modeluri: URI, timeout: number): void {
         if (!this.isSocketOpen(modeluri) && modeluri.toString() === 'Coffee.ecore') {
             this.intervalId = setInterval(
-                () => this.send(modeluri, { type: MessageType.keepAlive, data: '' }),
-                timeout > 1000 ? timeout - 50000 : 1
+                () => this.send(modeluri, { type: MessageType.keepAlive, data: undefined }),
+                timeout > 1000 ? timeout - 1000 : 1
             );
         }
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
     "lerna": "^4.0.0",
     "mocha": "^9.1.3",
     "mocha-jenkins-reporter": "^0.4.7",

--- a/packages/modelserver-client/package.json
+++ b/packages/modelserver-client/package.json
@@ -44,10 +44,12 @@
     "events": "^3.3.0",
     "fast-json-patch": "^3.1.0",
     "isomorphic-ws": "^4.0.1",
+    "urijs": "^1.19.11",
     "ws": "^7.4.6"
   },
   "devDependencies": {
     "@types/moxios": "0.4.14",
+    "@types/urijs": "^1.19.19",
     "@types/ws": "8.2.2",
     "ignore-styles": "^5.0.1",
     "moxios": "^0.4.0",

--- a/packages/modelserver-client/src/model-server-client-api-v1.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v1.ts
@@ -8,6 +8,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
+import URI from 'urijs';
+
 import { ModelServerCommand } from './model/command-model';
 import { Diagnostic } from './model/diagnostic';
 import { MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
@@ -28,7 +30,7 @@ export interface ModelServerClientApiV1 {
      * @param defaultFormat Optional fallback format that should used when a request method is invoked and no explicit format argument
      *                      has been passed.
      */
-    initialize(baseUrl: string, defaultFormat?: string): void | Promise<void>;
+    initialize(baseUrl: URI, defaultFormat?: string): void | Promise<void>;
 
     /**
      * Retrieves all available {@link Model}s of the current workspace as plain JSON objects.
@@ -56,7 +58,7 @@ export interface ModelServerClientApiV1 {
      * @param modeluri The URI of the model that should be retrieved
      * @returns The model typed as plain JSON object.
      */
-    get(modeluri: string): Promise<AnyObject>;
+    get(modeluri: URI): Promise<AnyObject>;
     /**
      * Retrieves the {@link Model} for a given URI as typed JSON object
      * The result promise is rejected if no matching model for the URI could be retrieved, or
@@ -65,7 +67,7 @@ export interface ModelServerClientApiV1 {
      * @param typeGuard A guard function to check if the received model is of the expected type.
      * @returns The model casted to the given type.
      */
-    get<M>(modeluri: string, typeGuard: TypeGuard<M>): Promise<M>;
+    get<M>(modeluri: URI, typeGuard: TypeGuard<M>): Promise<M>;
     /**
      * Retrieves the {@link Model} for a given URI in string representation derived from a given format (e.g. 'xml' or 'json').
      * The result promise is rejected if no matching model for the URI could be retrieved.
@@ -73,13 +75,13 @@ export interface ModelServerClientApiV1 {
      * @param format The desired format.
      * @returns The model in string representation.
      */
-    get(modeluri: string, format: string): Promise<string>;
+    get(modeluri: URI, format: string): Promise<string>;
 
     /**
      * Retrieves the URIs of all available {@link Model}s of the current workspace.
      * @returns A string array of all available model URIs.
      */
-    getModelUris(): Promise<string[]>;
+    getModelUris(): Promise<URI[]>;
 
     /**
      * Retrieves a specific model (sub)element by its `id` as plain JSON object.
@@ -88,7 +90,7 @@ export interface ModelServerClientApiV1 {
      * @param elementid The `id` of the element that should be retrieved.
      * @returns The model element typed as plain JSON object.
      */
-    getElementById(modeluri: string, elementid: string): Promise<AnyObject>;
+    getElementById(modeluri: URI, elementid: string): Promise<AnyObject>;
     /**
      * Retrieves a specific model (sub)element by its `id` as typed JSON object.
      * The result promise is rejected if no matching model element for the given URI and `id` could be retrieved, or
@@ -98,7 +100,7 @@ export interface ModelServerClientApiV1 {
      * @param typeGuard A guard function to check if the received model element is of the expected type.
      * @returns The model element casted to the given type.
      */
-    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>): Promise<M>;
+    getElementById<M>(modeluri: URI, elementid: string, typeGuard: TypeGuard<M>): Promise<M>;
     /**
      * Retrieves a specific model (sub)element by its `id` in string representation derived from a given format (e.g. 'xml' or 'json').
      * The result promise is rejected if no matching model element for the given URI and `id` could be retrieved.
@@ -107,7 +109,7 @@ export interface ModelServerClientApiV1 {
      * @param format The desired format.
      * @returns The model element in string representation.
      */
-    getElementById(modeluri: string, elementid: string, format: string): Promise<string>;
+    getElementById(modeluri: URI, elementid: string, format: string): Promise<string>;
 
     /**
      * Retrieves a specific model (sub)element by its `name` as plain JSON object.
@@ -116,7 +118,7 @@ export interface ModelServerClientApiV1 {
      * @param elementname The `name` of the element that should be retrieved.
      * @returns The model element typed as plain JSON object.
      */
-    getElementByName(modeluri: string, elementname: string): Promise<AnyObject>;
+    getElementByName(modeluri: URI, elementname: string): Promise<AnyObject>;
     /**
      * Retrieves a specific model (sub)element by its `name` as typed JSON object.
      * The result promise is rejected if no matching model element for the given URI and `name` could be retrieved, or
@@ -126,7 +128,7 @@ export interface ModelServerClientApiV1 {
      * @param typeGuard A guard function to check if the received model element is of the expected type.
      * @returns The model element casted to the given type.
      */
-    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    getElementByName<M>(modeluri: URI, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
     /**
      * Retrieves a specific model (sub)element by its `name` in string representation derived from a given format (e.g. 'xml' or 'json').
      * The result promise is rejected if no matching model element for the given URI and `name` could be retrieved.
@@ -135,21 +137,21 @@ export interface ModelServerClientApiV1 {
      * @param format The desired format.
      * @returns The model element in string representation.
      */
-    getElementByName(modeluri: string, elementname: string, format: string): Promise<string>;
+    getElementByName(modeluri: URI, elementname: string, format: string): Promise<string>;
 
     /**
      * Deletes the {@link Model} with the given URI from the current workspace.
      * @param modeluri The URI of the model that should be deleted.
      * @returns A boolean value indicating whether the deletion was successful.
      */
-    delete(modeluri: string): Promise<boolean>;
+    delete(modeluri: URI): Promise<boolean>;
 
     /**
      * Closes (i.e. unloads) the model with the given URI from the current workspace. This discards all dirty changes.
      * @param modeluri The URI of the model that should be closed.
      * @returns A boolean value indicating whether the close operation was successful.
      */
-    close(modeluri: string): Promise<boolean>;
+    close(modeluri: URI): Promise<boolean>;
 
     /**
      * Creates a new model object with the given URI and content object in the current workspace.
@@ -157,7 +159,7 @@ export interface ModelServerClientApiV1 {
      * @param model The content of the new model object either as plain JSON object or string.
      * @returns The newly created model as plain JSON object.
      */
-    create(modeluri: string, model: AnyObject | string): Promise<AnyObject>;
+    create(modeluri: URI, model: AnyObject | string): Promise<AnyObject>;
     /**
      * Creates a new model object with the given URI and content object in the current workspace.
      * The return type is derived from the given typeguard. The result promise is rejected if the newly created model didn't
@@ -167,7 +169,7 @@ export interface ModelServerClientApiV1 {
      * @param typeGuard A guard function to check if the received model element is of the expected type.
      * @returns The newly created model as typed JSON object `M`.
      */
-    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>): Promise<M>;
+    create<M>(modeluri: URI, model: AnyObject | string, typeGuard: TypeGuard<M>): Promise<M>;
     /**
      * Creates a new model object with the given URI and content string in the current workspace.
      * A `format` string has to passed to let the modelserver know how the given content should be interpreted.
@@ -176,7 +178,7 @@ export interface ModelServerClientApiV1 {
      * @param format The desired format.
      * @returns The newly created model as string.
      */
-    create(modeluri: string, model: string, format: string): Promise<string>;
+    create(modeluri: URI, model: string, format: string): Promise<string>;
 
     /**
      * Updates an existing model with the given URI with the given content in the current workspace.
@@ -185,7 +187,7 @@ export interface ModelServerClientApiV1 {
      * @param model The content of the updated model object either as string.
      * @returns The updated model as plain JSON object.
      */
-    update(modeluri: string, model: AnyObject | string): Promise<AnyObject>;
+    update(modeluri: URI, model: AnyObject | string): Promise<AnyObject>;
     /**
      * Updates an existing model with the given URI with the given content in the current workspace.
      * The return type is derived from the given typeguard. The result promise is rejected if the updated model didn't
@@ -196,7 +198,7 @@ export interface ModelServerClientApiV1 {
      * @param typeGuard A guard function to check if the received model element is of the expected type.
      * @returns The updated model as typed JSON object `M`.
      */
-    update<M>(modeluri: string, model: string | string, typeGuard: TypeGuard<M>): Promise<M>;
+    update<M>(modeluri: URI, model: string | string, typeGuard: TypeGuard<M>): Promise<M>;
     /**
      * Updates an existing model with the given URI with the given content string in the current workspace.
      * A `format` string has to passed to let the modelserver know how the given content should be interpreted.
@@ -205,14 +207,14 @@ export interface ModelServerClientApiV1 {
      * @param format The desired format.
      * @returns The updated model as string.
      */
-    update(modeluri: string, model: string, format: string): Promise<AnyObject>;
+    update(modeluri: URI, model: string, format: string): Promise<AnyObject>;
 
     /**
      * Persists all `dirty` changes for the model with the given URI.
      * @param modeluri The URI of the model whose dirty changes should be saved.
      * @returns A boolean indicating whether the saving was successful.
      */
-    save(modeluri: string): Promise<boolean>;
+    save(modeluri: URI): Promise<boolean>;
 
     /**
      * Saves (i.e. persists the dirty changes of) all models that are loaded in the current workspace.
@@ -225,14 +227,14 @@ export interface ModelServerClientApiV1 {
      * @param modeluri The URI of the model that should be validated.
      * @returns The validation result as {@link Diagnostic}.
      */
-    validate(modeluri: string): Promise<Diagnostic>;
+    validate(modeluri: URI): Promise<Diagnostic>;
 
     /**
      * Retrieves the EMF validation constraints for the model with the given URI
      * @param modeluri THe URI of the model whose constraints should be retrieved.
      * @returns The validation constraints as string.
      */
-    getValidationConstraints(modeluri: string): Promise<string>;
+    getValidationConstraints(modeluri: URI): Promise<string>;
 
     /**
      * Retrieves the JSON schema representation of the Ecore model with the given URI.
@@ -241,7 +243,7 @@ export interface ModelServerClientApiV1 {
      * @param modeluri The URI of the Ecore model whose JSON schema should be retrieved
      * @returns The corresponding JSON schema  as string.
      */
-    getTypeSchema(modeluri: string): Promise<string>;
+    getTypeSchema(modeluri: URI): Promise<string>;
 
     /**
      * Retrieves the JSONForms UI schema for the given EClass literal.
@@ -270,21 +272,21 @@ export interface ModelServerClientApiV1 {
      * @param command The command that should be executed.
      * @returns A promise indicating whether the command execution was successful.
      */
-    edit(modeluri: string, command: ModelServerCommand): Promise<boolean>;
+    edit(modeluri: URI, command: ModelServerCommand): Promise<boolean>;
 
     /**
      * Can be used to undo the latest edit change (i.e. command execution) for the model with the given URI.
      * @param modeluri The URI the model whose change should be undone.
      * @returns A string message indicating whether the change was successfully undone.
      */
-    undo(modeluri: string): Promise<string>;
+    undo(modeluri: URI): Promise<string>;
 
     /**
      * Can be used to redo the latest edit change (i.e. command execution) for the model with the given URI.
      * @param modeluri The URI the model whose change should be redone.
      * @returns A string message indicating whether the change was successfully redone.
      */
-    redo(modeluri: string): Promise<string>;
+    redo(modeluri: URI): Promise<string>;
 
     /**
      * Can be used to subscribe for model server notifications for the model with the given URI. For subscription communication
@@ -292,26 +294,26 @@ export interface ModelServerClientApiV1 {
      * @param modeluri URI of the model to subscribe for.
      * @param options The options to configure the subscriptions behavior.
      */
-    subscribe(modeluri: string, options?: SubscriptionOptions): void;
+    subscribe(modeluri: URI, options?: SubscriptionOptions): void;
 
     /**
      * Can be used to send arbitrary {@link ModelServerMessage}s to the model server via a subscription channel.
-     * @param modelUri The URI of the subscribed model.
+     * @param modeluri The URI of the subscribed model.
      * @param message The model server message that should be sent.
      * @returns A boolean indicating whether the message submission was successful.
      */
-    send(modelUri: string, message: ModelServerMessage): boolean;
+    send(modeluri: URI, message: ModelServerMessage): boolean;
 
     /**
      * Can be used to unsubscribe from model server notifications for the model with the given URI.
      * @param modeluri URI of the model to whose subscription should be canceled.
      * @returns A boolean indicating whether the unsubscribe process was successful.
      */
-    unsubscribe(modelUri: string): boolean;
+    unsubscribe(modeluri: URI): boolean;
 }
 
 export namespace ModelServerClientApiV1 {
-    export const API_ENDPOINT = '/api/v1';
+    export const API_ENDPOINT = 'api/v1';
 }
 
 /**

--- a/packages/modelserver-client/src/model-server-client-api-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v2.ts
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import { Operation } from 'fast-json-patch';
+import URI from 'urijs';
 
 import { ModelServerElement } from './model/base-model';
 import { ModelServerCommand } from './model/command-model';
@@ -70,14 +71,14 @@ export interface ModelServerClientApiV2 {
     /**
      * The `initialize` method should be executed before any other requests to the model server.
      * The given base url should point to the location of the model server API entry point.
-     * (e.g. `http://localhost:8081/api/v1/`). Once the initialization is completed the client is expected
+     * (e.g. `http://localhost:8081/api/v2/`). Once the initialization is completed the client is expected
      * to be ready and should be able to handle REST requests to & responses from the model server.
      * Any requests to the model server before the client has been initialized are expected to fail (i.e. throw an error)
      * @param baseUrl Url pointing to the API entry point
      * @param defaultFormat Optional fallback format that should used when a request method is invoked and no explicit format argument
      *                      has been passed. The default-default is `'json-v2'`
      */
-    initialize(baseUrl: string, defaultFormat?: Format): void | Promise<void>;
+    initialize(baseUrl: URI, defaultFormat?: Format): void | Promise<void>;
 
     /**
      * Retrieves all available models of the current workspace.
@@ -86,36 +87,36 @@ export interface ModelServerClientApiV2 {
     getAll<M>(typeGuard: TypeGuard<M>): Promise<Model<M>[]>;
     getAll(format: Format): Promise<Model<string>[]>;
 
-    get(modeluri: string, format?: Format): Promise<AnyObject>;
-    get<M>(modeluri: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
+    get(modeluri: URI, format?: Format): Promise<AnyObject>;
+    get<M>(modeluri: URI, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    getModelUris(): Promise<string[]>;
+    getModelUris(): Promise<URI[]>;
 
-    getElementById(modeluri: string, elementid: string, format?: Format): Promise<AnyObject>;
-    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
+    getElementById(modeluri: URI, elementid: string, format?: Format): Promise<AnyObject>;
+    getElementById<M>(modeluri: URI, elementid: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    getElementByName(modeluri: string, elementname: string, format?: Format): Promise<AnyObject>;
-    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
+    getElementByName(modeluri: URI, elementname: string, format?: Format): Promise<AnyObject>;
+    getElementByName<M>(modeluri: URI, elementname: string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    delete(modeluri: string): Promise<boolean>;
+    delete(modeluri: URI): Promise<boolean>;
 
-    close(modeluri: string): Promise<boolean>;
+    close(modeluri: URI): Promise<boolean>;
 
-    create(modeluri: string, model: AnyObject | string, format?: Format): Promise<AnyObject>;
-    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
+    create(modeluri: URI, model: AnyObject | string, format?: Format): Promise<AnyObject>;
+    create<M>(modeluri: URI, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    update(modeluri: string, model: AnyObject | string, format?: Format): Promise<AnyObject>;
-    update<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
+    update(modeluri: URI, model: AnyObject | string, format?: Format): Promise<AnyObject>;
+    update<M>(modeluri: URI, model: AnyObject | string, typeGuard: TypeGuard<M>, format?: Format): Promise<M>;
 
-    save(modeluri: string): Promise<boolean>;
+    save(modeluri: URI): Promise<boolean>;
 
     saveAll(): Promise<boolean>;
 
-    validate(modeluri: string): Promise<Diagnostic>;
+    validate(modeluri: URI): Promise<Diagnostic>;
 
-    getValidationConstraints(modeluri: string): Promise<string>;
+    getValidationConstraints(modeluri: URI): Promise<string>;
 
-    getTypeSchema(modeluri: string): Promise<string>;
+    getTypeSchema(modeluri: URI): Promise<string>;
 
     getUiSchema(schemaname: string): Promise<string>;
 
@@ -123,21 +124,21 @@ export interface ModelServerClientApiV2 {
 
     ping(): Promise<boolean>;
 
-    edit(modeluri: string, patchOrCommand: PatchOrCommand, format?: Format): Promise<ModelUpdateResult>;
+    edit(modeluri: URI, patchOrCommand: PatchOrCommand, format?: Format): Promise<ModelUpdateResult>;
 
-    undo(modeluri: string): Promise<ModelUpdateResult>;
+    undo(modeluri: URI): Promise<ModelUpdateResult>;
 
-    redo(modeluri: string): Promise<ModelUpdateResult>;
+    redo(modeluri: URI): Promise<ModelUpdateResult>;
 
     // WebSocket connection
-    subscribe(modeluri: string, listener: SubscriptionListener, options?: SubscriptionOptionsV2): SubscriptionListener;
+    subscribe(modeluri: URI, listener: SubscriptionListener, options?: SubscriptionOptionsV2): SubscriptionListener;
 
-    send(modelUri: string, message: ModelServerMessage): void;
-    unsubscribe(modelUri: string): void;
+    send(modeluri: URI, message: ModelServerMessage): void;
+    unsubscribe(modeluri: URI): void;
 }
 
 export namespace ModelServerClientApiV2 {
-    export const API_ENDPOINT = '/api/v2';
+    export const API_ENDPOINT = 'api/v2';
 }
 
 /**
@@ -173,12 +174,12 @@ export interface ModelUpdateResult {
      * @param copy by default, the patch will be directly applied to the oldModel, modifying
      * it in-place. If copy is true, the patch will be applied on a copy of the model, leaving
      * the original model unchanged.
-     * @param modelUri the uri of the model to patch. This can be used when the model is split in multiple
-     * resources, to identify the patch to apply. The modelUri should correspond to the oldModel object.
+     * @param modeluri the uri of the model to patch. This can be used when the model is split in multiple
+     * resources, to identify the patch to apply. The modeluri should correspond to the oldModel object.
      * It can be omitted when patching the main model (or in single-model cases).
      * @return the patched model.
      */
-    patchModel?(oldModel: ModelServerElement, copy?: boolean, modelUri?: string): ModelServerElement;
+    patchModel?(oldModel: ModelServerElement, copy?: boolean, modeluri?: URI): ModelServerElement;
 
     /**
      * The Json Patch describing the changes that were applied to the model. Only present if

--- a/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
@@ -240,7 +240,7 @@ describe('Integration tests for ModelServerClientV2', () => {
             const notification = await patchNotification;
             const patch = notification.patch;
 
-            expect(notification.modeluri.equals(modeluri)).to.be.true;
+            expect(notification.modeluri.toString()).to.be.equal(modeluri.toString());
             expect(patch.length).to.be.equal(1);
             const operation = patch[0];
             expect(Operations.isReplace(operation, 'string')).to.be.equal(true);
@@ -406,9 +406,9 @@ describe('Integration tests for ModelServerClientV2', () => {
             patchedMachine.children[1].processor.clockSpeed = 6;
 
             // Generate patches by diffing the original model and the patched one
-            const patches = jsonpatch.compare(machine, patchedMachine);
+            const patch = jsonpatch.compare(machine, patchedMachine);
 
-            const result = await client.edit(modeluri, patches);
+            const result = await client.edit(modeluri, patch);
             expect(result.success).to.be.true;
 
             expect(result.patch).to.not.be.undefined;

--- a/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2-integration.spec.ts
@@ -240,7 +240,7 @@ describe('Integration tests for ModelServerClientV2', () => {
             const notification = await patchNotification;
             const patch = notification.patch;
 
-            expect(notification.modeluri.toString()).to.be.equal(modeluri.toString());
+            expect(notification.modeluri.equals(modeluri)).to.be.true;
             expect(patch.length).to.be.equal(1);
             const operation = patch[0];
             expect(Operations.isReplace(operation, 'string')).to.be.equal(true);

--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -42,19 +42,19 @@ describe('tests for ModelServerClientV2', () => {
 
     it('initialize - correct baseUrl config of axios instance', () => {
         const axios = client['restClient'];
-        expect(axios.defaults.baseURL).to.be.equal(baseUrl.toString());
+        expect(baseUrl.equals(axios.defaults.baseURL)).to.be.true;
     });
     it('test createSubscriptionPath without trailing slash', () => {
         client = new ModelServerClientV2();
         client.initialize(baseUrl);
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2');
+        expect(subscriptionPath.equals('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2')).to.be.true;
     });
     it('test createSubscriptionPath with trailing slash', () => {
         client = new ModelServerClientV2();
         client.initialize(new URI(`${baseUrl}/`));
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2');
+        expect(subscriptionPath.equals('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2')).to.be.true;
     });
 
     describe('test requests', () => {
@@ -66,7 +66,7 @@ describe('tests for ModelServerClientV2', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2 });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI });
@@ -80,7 +80,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_URIS);
                 done();
             });
@@ -97,7 +97,7 @@ describe('tests for ModelServerClientV2', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, elementid, modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, elementid, modeluri: modeluri.toString() });
@@ -116,7 +116,7 @@ describe('tests for ModelServerClientV2', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, elementname, modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, elementname, modeluri: modeluri.toString() });
@@ -131,7 +131,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('delete');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
@@ -144,7 +144,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.CLOSE);
                 done();
             });
@@ -162,7 +162,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, modeluri: modeluri.toString() });
@@ -182,7 +182,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, modeluri: modeluri.toString() });
@@ -197,7 +197,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE);
                 done();
             });
@@ -209,7 +209,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE_ALL);
                 done();
             });
@@ -222,7 +222,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION);
                 done();
             });
@@ -235,7 +235,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION_CONSTRAINTS);
                 done();
             });
@@ -248,7 +248,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.TYPE_SCHEMA);
                 done();
             });
@@ -261,7 +261,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ schemaname });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.UI_SCHEMA);
                 done();
             });
@@ -278,7 +278,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.equal(JSON.stringify(configuration));
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);
                 done();
             });
@@ -290,7 +290,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_PING);
                 done();
             });
@@ -316,7 +316,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data: expected }));
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
@@ -329,7 +329,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.UNDO);
                 done();
             });
@@ -342,7 +342,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri: modeluri.toString() });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.REDO);
                 done();
             });

--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -42,19 +42,19 @@ describe('tests for ModelServerClientV2', () => {
 
     it('initialize - correct baseUrl config of axios instance', () => {
         const axios = client['restClient'];
-        expect(baseUrl.equals(axios.defaults.baseURL)).to.be.true;
+        expect(axios.defaults.baseURL).to.be.equal(baseUrl.toString());
     });
     it('test createSubscriptionPath without trailing slash', () => {
         client = new ModelServerClientV2();
         client.initialize(baseUrl);
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.equals('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2')).to.be.true;
+        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2');
     });
     it('test createSubscriptionPath with trailing slash', () => {
         client = new ModelServerClientV2();
         client.initialize(new URI(`${baseUrl}/`));
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.equals('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2')).to.be.true;
+        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v2/subscribe?modeluri=foo&format=json-v2');
     });
 
     describe('test requests', () => {
@@ -66,7 +66,7 @@ describe('tests for ModelServerClientV2', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2 });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI });
@@ -80,7 +80,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_URIS);
                 done();
             });
@@ -97,7 +97,7 @@ describe('tests for ModelServerClientV2', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, elementid, modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, elementid, modeluri: modeluri.toString() });
@@ -116,7 +116,7 @@ describe('tests for ModelServerClientV2', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, elementname, modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, elementname, modeluri: modeluri.toString() });
@@ -131,7 +131,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('delete');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
@@ -144,7 +144,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.CLOSE);
                 done();
             });
@@ -162,7 +162,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, modeluri: modeluri.toString() });
@@ -182,7 +182,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: FORMAT_XMI, modeluri: modeluri.toString() });
@@ -197,7 +197,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE);
                 done();
             });
@@ -209,7 +209,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE_ALL);
                 done();
             });
@@ -222,7 +222,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION);
                 done();
             });
@@ -235,7 +235,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION_CONSTRAINTS);
                 done();
             });
@@ -248,7 +248,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.TYPE_SCHEMA);
                 done();
             });
@@ -261,7 +261,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ schemaname });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.UI_SCHEMA);
                 done();
             });
@@ -278,7 +278,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.equal(JSON.stringify(configuration));
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);
                 done();
             });
@@ -290,7 +290,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_PING);
                 done();
             });
@@ -316,7 +316,7 @@ describe('tests for ModelServerClientV2', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data: expected }));
                 expect(request.config.params).to.include({ format: FORMAT_JSON_V2, modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
@@ -329,7 +329,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.UNDO);
                 done();
             });
@@ -342,7 +342,7 @@ describe('tests for ModelServerClientV2', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri: modeluri.toString() });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.REDO);
                 done();
             });

--- a/packages/modelserver-client/src/model-server-client.spec.ts
+++ b/packages/modelserver-client/src/model-server-client.spec.ts
@@ -14,11 +14,11 @@ import moxios from 'moxios';
 import { spy } from 'sinon';
 import URI from 'urijs';
 
-import { SetCommand } from './model/command-model';
 import { ModelServerClient } from './model-server-client';
 import { ModelServerClientApiV1, ServerConfiguration } from './model-server-client-api-v1';
 import { Model, ModelServerMessage } from './model-server-message';
 import { ModelServerPaths } from './model-server-paths';
+import { SetCommand } from './model/command-model';
 
 describe('tests for ModelServerClient', () => {
     let client: ModelServerClient;
@@ -41,19 +41,19 @@ describe('tests for ModelServerClient', () => {
 
     it('initialize - correct baseUrl config of axios instance', () => {
         const axios = client['restClient'];
-        expect(axios.defaults.baseURL).to.be.equal(baseUrl.toString());
+        expect(baseUrl.equals(axios.defaults.baseURL)).to.be.true;
     });
     it('test createSubscriptionPath without trailing slash', () => {
         client = new ModelServerClient();
         client.initialize(baseUrl);
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json');
+        expect(subscriptionPath.equals('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json')).to.be.true;
     });
     it('test createSubscriptionPath with trailing slash', () => {
         client = new ModelServerClient();
         client.initialize(new URI(baseUrl));
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json');
+        expect(subscriptionPath.equals('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json')).to.be.true;
     });
 
     describe('test requests', () => {
@@ -65,7 +65,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json' });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml' });
@@ -79,7 +79,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_URIS);
                 done();
             });
@@ -96,7 +96,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json', elementid, modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', elementid, modeluri });
@@ -115,7 +115,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json', elementname, modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', elementname, modeluri });
@@ -130,7 +130,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('delete');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
@@ -143,7 +143,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.CLOSE);
                 done();
             });
@@ -161,7 +161,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', modeluri });
@@ -181,7 +181,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', modeluri });
@@ -196,7 +196,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE);
                 done();
             });
@@ -208,7 +208,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE_ALL);
                 done();
             });
@@ -221,7 +221,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION);
                 done();
             });
@@ -234,7 +234,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION_CONSTRAINTS);
                 done();
             });
@@ -247,7 +247,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.TYPE_SCHEMA);
                 done();
             });
@@ -260,7 +260,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ schemaname });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.UI_SCHEMA);
                 done();
             });
@@ -277,7 +277,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.equal(JSON.stringify(configuration));
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);
                 done();
             });
@@ -289,7 +289,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_PING);
                 done();
             });
@@ -313,7 +313,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data: command }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.EDIT);
                 done();
             });
@@ -326,7 +326,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.UNDO);
                 done();
             });
@@ -339,7 +339,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
+                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
                 expect(request.config.url).to.be.equal(ModelServerPaths.REDO);
                 done();
             });

--- a/packages/modelserver-client/src/model-server-client.spec.ts
+++ b/packages/modelserver-client/src/model-server-client.spec.ts
@@ -41,19 +41,19 @@ describe('tests for ModelServerClient', () => {
 
     it('initialize - correct baseUrl config of axios instance', () => {
         const axios = client['restClient'];
-        expect(baseUrl.equals(axios.defaults.baseURL)).to.be.true;
+        expect(axios.defaults.baseURL).to.be.equal(baseUrl.toString());
     });
     it('test createSubscriptionPath without trailing slash', () => {
         client = new ModelServerClient();
         client.initialize(baseUrl);
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.equals('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json')).to.be.true;
+        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json');
     });
     it('test createSubscriptionPath with trailing slash', () => {
         client = new ModelServerClient();
-        client.initialize(new URI(baseUrl));
+        client.initialize(new URI(`${baseUrl}/`));
         const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
-        expect(subscriptionPath.equals('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json')).to.be.true;
+        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json');
     });
 
     describe('test requests', () => {
@@ -65,7 +65,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json' });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml' });
@@ -79,7 +79,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_URIS);
                 done();
             });
@@ -96,7 +96,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json', elementid, modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', elementid, modeluri });
@@ -115,7 +115,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json', elementname, modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', elementname, modeluri });
@@ -130,7 +130,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('delete');
                 expect(request.config.params).to.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
@@ -143,7 +143,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.params).to.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.CLOSE);
                 done();
             });
@@ -161,7 +161,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', modeluri });
@@ -181,7 +181,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', modeluri });
@@ -196,7 +196,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE);
                 done();
             });
@@ -208,7 +208,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE_ALL);
                 done();
             });
@@ -221,7 +221,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION);
                 done();
             });
@@ -234,7 +234,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION_CONSTRAINTS);
                 done();
             });
@@ -247,7 +247,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.TYPE_SCHEMA);
                 done();
             });
@@ -260,7 +260,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ schemaname });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.UI_SCHEMA);
                 done();
             });
@@ -277,7 +277,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.equal(JSON.stringify(configuration));
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);
                 done();
             });
@@ -289,7 +289,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_PING);
                 done();
             });
@@ -313,7 +313,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data: command }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.EDIT);
                 done();
             });
@@ -326,7 +326,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.UNDO);
                 done();
             });
@@ -339,7 +339,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri });
-                expect(baseUrl.equals(request.config.baseURL)).to.be.true;
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.REDO);
                 done();
             });

--- a/packages/modelserver-client/src/model-server-client.spec.ts
+++ b/packages/modelserver-client/src/model-server-client.spec.ts
@@ -12,6 +12,7 @@ import { strictEqual } from 'assert';
 import { expect } from 'chai';
 import moxios from 'moxios';
 import { spy } from 'sinon';
+import URI from 'urijs';
 
 import { SetCommand } from './model/command-model';
 import { ModelServerClient } from './model-server-client';
@@ -21,7 +22,12 @@ import { ModelServerPaths } from './model-server-paths';
 
 describe('tests for ModelServerClient', () => {
     let client: ModelServerClient;
-    const baseUrl = `http://localhost:8081${ModelServerClientApiV1.API_ENDPOINT}`;
+    const baseUrl = new URI({
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '8081',
+        path: ModelServerClientApiV1.API_ENDPOINT
+    });
 
     beforeEach(() => {
         client = new ModelServerClient();
@@ -35,20 +41,19 @@ describe('tests for ModelServerClient', () => {
 
     it('initialize - correct baseUrl config of axios instance', () => {
         const axios = client['restClient'];
-        expect(axios.defaults.baseURL).to.be.equal(baseUrl);
+        expect(axios.defaults.baseURL).to.be.equal(baseUrl.toString());
     });
-
     it('test createSubscriptionPath without trailing slash', () => {
         client = new ModelServerClient();
         client.initialize(baseUrl);
-        const subscriptionPath = client['createSubscriptionPath']('foo', {});
-        expect(subscriptionPath).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo');
+        const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
+        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json');
     });
     it('test createSubscriptionPath with trailing slash', () => {
         client = new ModelServerClient();
-        client.initialize(`${baseUrl}/`);
-        const subscriptionPath = client['createSubscriptionPath']('foo', {});
-        expect(subscriptionPath).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo');
+        client.initialize(new URI(baseUrl));
+        const subscriptionPath = client['createSubscriptionPath'](new URI('foo'), {});
+        expect(subscriptionPath.toString()).to.be.equal('ws://localhost:8081/api/v1/subscribe?modeluri=foo&format=json');
     });
 
     describe('test requests', () => {
@@ -60,7 +65,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json' });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml' });
@@ -74,14 +79,14 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_URIS);
                 done();
             });
         });
 
         it('getElementById', done => {
-            const modeluri = 'my/uri.model';
+            const modeluri = new URI('my/uri.model');
             const elementid = 'myElement';
 
             client.getElementById(modeluri, elementid);
@@ -91,7 +96,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json', elementid, modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', elementid, modeluri });
@@ -100,7 +105,7 @@ describe('tests for ModelServerClient', () => {
         });
 
         it('getElementByName', done => {
-            const modeluri = 'my/uri.model';
+            const modeluri = new URI('my/uri.model');
             const elementname = 'myElement';
 
             client.getElementByName(modeluri, elementname);
@@ -110,7 +115,7 @@ describe('tests for ModelServerClient', () => {
                 let request = moxios.requests.at(0);
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ format: 'json', elementname, modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_ELEMENT);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', elementname, modeluri });
@@ -119,33 +124,33 @@ describe('tests for ModelServerClient', () => {
         });
 
         it('delete', done => {
-            const modeluri = 'delete/me/please';
+            const modeluri = new URI('delete/me/please');
             client.delete(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('delete');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 done();
             });
         });
 
         it('close', done => {
-            const modeluri = 'delete/me/please';
+            const modeluri = new URI('delete/me/please');
             client.close(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.CLOSE);
                 done();
             });
         });
 
         it('create', done => {
-            const modeluri = 'delete/me/please';
+            const modeluri = new URI('delete/me/please');
             const model = { name: 'myModel', id: 'myModelId' };
             const data = JSON.stringify(model);
             client.create(modeluri, data);
@@ -156,7 +161,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('post');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', modeluri });
@@ -165,7 +170,7 @@ describe('tests for ModelServerClient', () => {
         });
 
         it('update', done => {
-            const modeluri = 'delete/me/please';
+            const modeluri = new URI('delete/me/please');
             const model = { name: 'myModel', id: 'myModelId' };
             const data = JSON.stringify(model);
             client.update(modeluri, data);
@@ -176,7 +181,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.MODEL_CRUD);
                 request = moxios.requests.at(1);
                 expect(request.config.params).to.include({ format: 'xml', modeluri });
@@ -185,13 +190,13 @@ describe('tests for ModelServerClient', () => {
         });
 
         it('save', done => {
-            const modeluri = 'save/me/please';
+            const modeluri = new URI('save/me/please');
             client.save(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE);
                 done();
             });
@@ -203,46 +208,46 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SAVE_ALL);
                 done();
             });
         });
 
         it('validate', done => {
-            const modeluri = 'validate/me/please';
+            const modeluri = new URI('validate/me/please');
             client.validate(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION);
                 done();
             });
         });
 
         it('getValidationConstraints', done => {
-            const modeluri = 'validate/me/please';
+            const modeluri = new URI('validate/me/please');
             client.getValidationConstraints(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.VALIDATION_CONSTRAINTS);
                 done();
             });
         });
 
         it('getTypeSchema', done => {
-            const modeluri = 'my/model/uri';
+            const modeluri = new URI('my/model/uri');
             client.getTypeSchema(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.TYPE_SCHEMA);
                 done();
             });
@@ -255,7 +260,7 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.include({ schemaname });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.UI_SCHEMA);
                 done();
             });
@@ -272,7 +277,7 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('put');
                 expect(request.config.data).to.equal(JSON.stringify(configuration));
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);
                 done();
             });
@@ -284,14 +289,14 @@ describe('tests for ModelServerClient', () => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.undefined;
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_PING);
                 done();
             });
         });
 
         it('edit', done => {
-            const modeluri = 'edit/me/please';
+            const modeluri = new URI('edit/me/please');
             const command = new SetCommand(
                 {
                     eClass: 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow',
@@ -308,33 +313,33 @@ describe('tests for ModelServerClient', () => {
                 expect(request.config.method).to.be.equal('patch');
                 expect(request.config.data).to.be.equal(JSON.stringify({ data: command }));
                 expect(request.config.params).to.include({ format: 'json', modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.EDIT);
                 done();
             });
         });
 
         it('undo', done => {
-            const modeluri = 'undo/me/please';
+            const modeluri = new URI('undo/me/please');
             client.undo(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.UNDO);
                 done();
             });
         });
 
         it('redo', done => {
-            const modeluri = 'redo/me/please';
+            const modeluri = new URI('redo/me/please');
             client.redo(modeluri);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('get');
                 expect(request.config.params).to.be.include({ modeluri });
-                expect(request.config.baseURL).to.be.equal(baseUrl);
+                expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.REDO);
                 done();
             });
@@ -342,7 +347,7 @@ describe('tests for ModelServerClient', () => {
     });
 
     describe('test responses', () => {
-        it('ping ', done => {
+        it('ping', done => {
             const expectedMsg: ModelServerMessage = {
                 data: '',
                 type: 'success'
@@ -362,21 +367,21 @@ describe('tests for ModelServerClient', () => {
 
         it('getAll ', done => {
             const model1: Model = {
-                modelUri: 'path/to/model1',
+                modeluri: 'file:/path/to/model1',
                 content: {
                     name: 'coffee'
                 }
             };
             const model2: Model = {
-                modelUri: 'path/to/model2',
+                modeluri: 'file:/path/to/model2',
                 content: {
                     name: 'coffee'
                 }
             };
             const response: ModelServerMessage = {
                 data: {
-                    [model1.modelUri]: model1.content,
-                    [model2.modelUri]: model2.content
+                    [model1.modeluri]: model1.content,
+                    [model2.modeluri]: model2.content
                 },
                 type: 'success'
             };
@@ -389,7 +394,8 @@ describe('tests for ModelServerClient', () => {
                     response
                 });
                 const result = onFulfilled.getCall(0).args[0];
-                expect(result).to.deep.include.members([model2, model1]);
+                expect(result).to.be.an('array').of.length(2);
+                expect(result).to.deep.include.members([model1, model2]);
                 done();
             });
         });

--- a/packages/modelserver-client/src/model-server-client.ts
+++ b/packages/modelserver-client/src/model-server-client.ts
@@ -10,12 +10,13 @@
  *******************************************************************************/
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import WebSocket from 'isomorphic-ws';
+import URI from 'urijs';
 
-import { ModelServerCommand } from './model/command-model';
-import { Diagnostic } from './model/diagnostic';
 import { ModelServerClientApiV1, ModelServerError, ServerConfiguration, SubscriptionOptions } from './model-server-client-api-v1';
 import { IdentityMapper, Mapper, MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
 import { ModelServerPaths } from './model-server-paths';
+import { ModelServerCommand } from './model/command-model';
+import { Diagnostic } from './model/diagnostic';
 import { SubscriptionListener } from './subscription-listener';
 import { AnyObject, asObject, asString, asType, TypeGuard } from './utils/type-util';
 
@@ -25,22 +26,22 @@ import { AnyObject, asObject, asString, asType, TypeGuard } from './utils/type-u
 export class ModelServerClient implements ModelServerClientApiV1 {
     protected restClient: AxiosInstance;
     protected openSockets: Map<string, WebSocket> = new Map();
-    protected _baseUrl: string;
+    protected _baseUrl: URI;
     protected defaultFormat = 'json';
 
-    initialize(baseUrl: string): void | Promise<void> {
-        this._baseUrl = baseUrl.endsWith('/') ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl;
+    initialize(baseUrl: URI): void | Promise<void> {
+        this._baseUrl = baseUrl.clone();
         this.restClient = axios.create(this.getAxisConfig(baseUrl));
     }
 
-    protected getAxisConfig(baseURL: string): AxiosRequestConfig | undefined {
-        return { baseURL };
+    protected getAxisConfig(baseURL: URI): AxiosRequestConfig | undefined {
+        return { baseURL: baseURL.toString() };
     }
 
-    get(modeluri: string): Promise<AnyObject>;
-    get<M>(modeluri: string, typeGuard: TypeGuard<M>): Promise<M>;
-    get(modeluri: string, format: string): Promise<string>;
-    get<M>(modeluri: string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
+    get(modeluri: URI): Promise<AnyObject>;
+    get<M>(modeluri: URI, typeGuard: TypeGuard<M>): Promise<M>;
+    get(modeluri: URI, format: string): Promise<string>;
+    get<M>(modeluri: URI, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
         const format = typeof formatOrGuard === 'string' ? formatOrGuard : this.defaultFormat;
         const mapper = createMapper<M>(formatOrGuard);
         return this.process(this.restClient.get(ModelServerPaths.MODEL_CRUD, { params: { modeluri, format } }), mapper);
@@ -67,55 +68,55 @@ export class ModelServerClient implements ModelServerClientApiV1 {
         return this.process(this.restClient.get(ModelServerPaths.MODEL_CRUD, { params: { format } }), messageMapper);
     }
 
-    getModelUris(): Promise<string[]> {
-        return this.process(this.restClient.get(ModelServerPaths.MODEL_URIS), MessageDataMapper.asStringArray);
+    getModelUris(): Promise<URI[]> {
+        return this.process(this.restClient.get(ModelServerPaths.MODEL_URIS), MessageDataMapper.asURIArray);
     }
 
-    getElementById(modeluri: string, elementid: string): Promise<AnyObject>;
-    getElementById<M>(modeluri: string, elementid: string, typeGuard: TypeGuard<M>): Promise<M>;
-    getElementById(modeluri: string, elementid: string, format: string): Promise<string>;
-    getElementById<M>(modeluri: string, elementid: string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
+    getElementById(modeluri: URI, elementid: string): Promise<AnyObject>;
+    getElementById<M>(modeluri: URI, elementid: string, typeGuard: TypeGuard<M>): Promise<M>;
+    getElementById(modeluri: URI, elementid: string, format: string): Promise<string>;
+    getElementById<M>(modeluri: URI, elementid: string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
         const format = typeof formatOrGuard === 'string' ? formatOrGuard : this.defaultFormat;
         const mapper = createMapper<M>(formatOrGuard);
         return this.process(this.restClient.get(ModelServerPaths.MODEL_ELEMENT, { params: { modeluri, elementid, format } }), mapper);
     }
 
-    getElementByName(modeluri: string, elementname: string): Promise<AnyObject>;
-    getElementByName<M>(modeluri: string, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
-    getElementByName(modeluri: string, elementname: string, format: string): Promise<string>;
-    getElementByName<M>(modeluri: string, elementname: string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
+    getElementByName(modeluri: URI, elementname: string): Promise<AnyObject>;
+    getElementByName<M>(modeluri: URI, elementname: string, typeGuard: TypeGuard<M>, format?: string): Promise<M>;
+    getElementByName(modeluri: URI, elementname: string, format: string): Promise<string>;
+    getElementByName<M>(modeluri: URI, elementname: string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
         const format = typeof formatOrGuard === 'string' ? formatOrGuard : this.defaultFormat;
         const mapper = createMapper<M>(formatOrGuard);
         return this.process(this.restClient.get(ModelServerPaths.MODEL_ELEMENT, { params: { modeluri, elementname, format } }), mapper);
     }
 
-    create(modeluri: string, model: AnyObject | string): Promise<AnyObject>;
-    create(modeluri: string, model: AnyObject | string, format: string): Promise<string>;
-    create<M>(modeluri: string, model: AnyObject | string, typeGuard: TypeGuard<M>): Promise<M>;
-    create<M>(modeluri: string, model: AnyObject | string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
+    create(modeluri: URI, model: AnyObject | string): Promise<AnyObject>;
+    create(modeluri: URI, model: AnyObject | string, format: string): Promise<string>;
+    create<M>(modeluri: URI, model: AnyObject | string, typeGuard: TypeGuard<M>): Promise<M>;
+    create<M>(modeluri: URI, model: AnyObject | string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
         const format = typeof formatOrGuard === 'string' ? formatOrGuard : this.defaultFormat;
         const mapper = createMapper<M>(formatOrGuard);
         return this.process(this.restClient.post(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }), mapper);
     }
 
-    update(modeluri: string, model: AnyObject | string): Promise<AnyObject>;
-    update<M>(modeluri: string, model: string | string, typeGuard: TypeGuard<M>): Promise<M>;
-    update(modeluri: string, model: AnyObject | string, format: string): Promise<AnyObject>;
-    update<M>(modeluri: string, model: AnyObject | string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
+    update(modeluri: URI, model: AnyObject | string): Promise<AnyObject>;
+    update<M>(modeluri: URI, model: string | string, typeGuard: TypeGuard<M>): Promise<M>;
+    update(modeluri: URI, model: AnyObject | string, format: string): Promise<AnyObject>;
+    update<M>(modeluri: URI, model: AnyObject | string, formatOrGuard?: FormatOrGuard<M>): Promise<AnyObject | M | string> {
         const format = typeof formatOrGuard === 'string' ? formatOrGuard : this.defaultFormat;
         const mapper = createMapper<M>(formatOrGuard);
         return this.process(this.restClient.patch(ModelServerPaths.MODEL_CRUD, { data: model }, { params: { modeluri, format } }), mapper);
     }
 
-    delete(modeluri: string): Promise<boolean> {
+    delete(modeluri: URI): Promise<boolean> {
         return this.process(this.restClient.delete(ModelServerPaths.MODEL_CRUD, { params: { modeluri } }), MessageDataMapper.isSuccess);
     }
 
-    close(modeluri: string): Promise<boolean> {
+    close(modeluri: URI): Promise<boolean> {
         return this.process(this.restClient.post(ModelServerPaths.CLOSE, undefined, { params: { modeluri } }), MessageDataMapper.isSuccess);
     }
 
-    save(modeluri: string): Promise<boolean> {
+    save(modeluri: URI): Promise<boolean> {
         return this.process(this.restClient.get(ModelServerPaths.SAVE, { params: { modeluri } }), MessageDataMapper.isSuccess);
     }
 
@@ -123,20 +124,20 @@ export class ModelServerClient implements ModelServerClientApiV1 {
         return this.process(this.restClient.get(ModelServerPaths.SAVE_ALL), MessageDataMapper.isSuccess);
     }
 
-    validate(modeluri: string): Promise<Diagnostic> {
+    validate(modeluri: URI): Promise<Diagnostic> {
         return this.process(this.restClient.get(ModelServerPaths.VALIDATION, { params: { modeluri } }), response =>
             MessageDataMapper.as(response, Diagnostic.is)
         );
     }
 
-    getValidationConstraints(modeluri: string): Promise<string> {
+    getValidationConstraints(modeluri: URI): Promise<string> {
         return this.process(
             this.restClient.get(ModelServerPaths.VALIDATION_CONSTRAINTS, { params: { modeluri } }),
             MessageDataMapper.asString
         );
     }
 
-    getTypeSchema(modeluri: string): Promise<string> {
+    getTypeSchema(modeluri: URI): Promise<string> {
         return this.process(this.restClient.get(ModelServerPaths.TYPE_SCHEMA, { params: { modeluri } }), MessageDataMapper.asString);
     }
 
@@ -158,23 +159,23 @@ export class ModelServerClient implements ModelServerClientApiV1 {
         return this.process(this.restClient.get(ModelServerPaths.SERVER_PING), MessageDataMapper.isSuccess);
     }
 
-    edit(modeluri: string, command: ModelServerCommand): Promise<boolean> {
+    edit(modeluri: URI, command: ModelServerCommand): Promise<boolean> {
         return this.process(
             this.restClient.patch(ModelServerPaths.EDIT, { data: command }, { params: { modeluri, format: this.defaultFormat } }),
             MessageDataMapper.isSuccess
         );
     }
 
-    undo(modeluri: string): Promise<string> {
+    undo(modeluri: URI): Promise<string> {
         return this.process(this.restClient.get(ModelServerPaths.UNDO, { params: { modeluri } }), MessageDataMapper.asString);
     }
 
-    redo(modeluri: string): Promise<string> {
+    redo(modeluri: URI): Promise<string> {
         return this.process(this.restClient.get(ModelServerPaths.REDO, { params: { modeluri } }), MessageDataMapper.asString);
     }
 
-    send(modelUri: string, message: ModelServerMessage): boolean {
-        const openSocket = this.openSockets.get(modelUri);
+    send(modeluri: URI, message: ModelServerMessage): boolean {
+        const openSocket = this.openSockets.get(modeluri.toString());
         if (openSocket) {
             openSocket.send(JSON.stringify(message));
             return true;
@@ -182,13 +183,13 @@ export class ModelServerClient implements ModelServerClientApiV1 {
         return false;
     }
 
-    subscribe(modeluri: string, options: SubscriptionOptions = {}): void {
+    subscribe(modeluri: URI, options: SubscriptionOptions = {}): void {
         if (!options.listener) {
-            const errorMsg = `${modeluri} : Cannot subscribe. No listener is present!'`;
+            const errorMsg = `${modeluri.toString()} : Cannot subscribe. No listener is present!'`;
             throw new Error(errorMsg);
         }
         if (this.isSocketOpen(modeluri)) {
-            const errorMsg = `${modeluri} : Cannot open new socket, already subscribed!'`;
+            const errorMsg = `${modeluri.toString()} : Cannot open new socket, already subscribed!'`;
             console.warn(errorMsg);
             if (options.errorWhenUnsuccessful) {
                 throw new Error(errorMsg);
@@ -198,44 +199,44 @@ export class ModelServerClient implements ModelServerClientApiV1 {
         this.doSubscribe(options.listener, modeluri, path);
     }
 
-    unsubscribe(modeluri: string): boolean {
-        const openSocket = this.openSockets.get(modeluri);
+    unsubscribe(modeluri: URI): boolean {
+        const openSocket = this.openSockets.get(modeluri.toString());
         if (openSocket) {
             openSocket.close();
-            this.openSockets.delete(modeluri);
+            this.openSockets.delete(modeluri.toString());
             return true;
         }
         return false;
     }
 
-    protected createSubscriptionPath(modeluri: string, options: SubscriptionOptions): string {
+    protected createSubscriptionPath(modeluri: URI, options: SubscriptionOptions): URI {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { listener, ...paramOptions } = options;
-        const queryParams = new URLSearchParams();
-        queryParams.append('modeluri', modeluri);
-        if (!options.format) {
-            options.format = this.defaultFormat;
-        }
-        Object.entries(paramOptions).forEach(entry => queryParams.append(entry[0], entry[1].toString()));
-        queryParams.delete('errorWhenUnsuccessful');
-        return `${this._baseUrl}/${ModelServerPaths.SUBSCRIPTION}?${queryParams.toString()}`.replace(/^(http|https):\/\//i, 'ws://');
+        const subscriptionUri = this._baseUrl.clone();
+        subscriptionUri.protocol('ws');
+        subscriptionUri.segment(ModelServerPaths.SUBSCRIPTION);
+        subscriptionUri.addQuery('modeluri', modeluri);
+        subscriptionUri.addQuery('format', options.format || this.defaultFormat);
+        Object.entries(paramOptions).forEach(entry => subscriptionUri.addQuery(entry[0], entry[1]));
+        subscriptionUri.removeQuery('errorWhenUnsuccessful');
+        return subscriptionUri;
     }
 
-    protected doSubscribe(listener: SubscriptionListener, modelUri: string, path: string): void {
-        const socket = new WebSocket(path.trim());
-        socket.onopen = event => listener.onOpen(modelUri, event);
+    protected doSubscribe(listener: SubscriptionListener, modeluri: URI, path: URI): void {
+        const socket = new WebSocket(path.toString() /* .trim() */);
+        socket.onopen = event => listener.onOpen(modeluri, event);
         socket.onclose = event => {
-            listener.onClose(modelUri, event);
-            this.openSockets.delete(modelUri);
+            listener.onClose(modeluri, event);
+            this.openSockets.delete(modeluri.toString());
         };
 
-        socket.onerror = event => listener.onError(modelUri, event);
-        socket.onmessage = event => listener.onMessage(modelUri, event);
-        this.openSockets.set(modelUri, socket);
+        socket.onerror = event => listener.onError(modeluri, event);
+        socket.onmessage = event => listener.onMessage(modeluri, event);
+        this.openSockets.set(modeluri.toString(), socket);
     }
 
-    protected isSocketOpen(modelUri: string): boolean {
-        return this.openSockets.get(modelUri) !== undefined;
+    protected isSocketOpen(modeluri: URI): boolean {
+        return this.openSockets.get(modeluri.toString()) !== undefined;
     }
 
     protected async process<T>(request: Promise<AxiosResponse<ModelServerMessage>>, mapper: MessageDataMapper<T>): Promise<T> {
@@ -302,11 +303,11 @@ function createMapper<M>(formatOrGuard?: FormatOrGuard<M>): MessageDataMapper<An
 }
 
 function mapModel<M>(model: Model, guard?: TypeGuard<M>, toString = false): Model<AnyObject | M | string> {
-    const { modelUri, content } = model;
+    const { modeluri, content } = model;
     if (guard) {
-        return { modelUri, content: asType(content, guard) };
+        return { modeluri, content: asType(content, guard) };
     } else if (toString) {
-        return { modelUri, content: asString(content) };
+        return { modeluri, content: asString(content) };
     }
-    return { modelUri, content: asObject(content) };
+    return { modeluri, content: asObject(content) };
 }

--- a/packages/modelserver-client/src/model-server-notification.ts
+++ b/packages/modelserver-client/src/model-server-notification.ts
@@ -9,25 +9,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import { Operation } from 'fast-json-patch';
+import * as URI from 'urijs';
 
 import { MessageType, ModelServerObjectV2 } from '.';
 import { CommandExecutionResult } from './model/command-model';
 import { Diagnostic } from './model/diagnostic';
 import { ModelServerMessage } from './model-server-message';
-import { AnyObject, isString } from './utils/type-util';
+import { AnyObject, isObject, isString } from './utils/type-util';
 
 /**
  * A `ModelServerNotification` represents the payload object that is sent by the modelserver over websocket to
  * notify subscribers about the current model state.
  */
 export interface ModelServerNotification {
-    modelUri: string;
+    modeluri: URI;
     type: string;
 }
 
 export namespace ModelServerNotification {
     export function is(object?: unknown): object is ModelServerNotification {
-        return AnyObject.is(object) && isString(object, 'modelUri') && isString(object, 'type');
+        return AnyObject.is(object) && isObject(object, 'modeluri') && isString(object, 'type');
     }
 }
 

--- a/packages/modelserver-client/src/utils/patch-utils.ts
+++ b/packages/modelserver-client/src/utils/patch-utils.ts
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import { AddOperation, Operation, RemoveOperation, ReplaceOperation } from 'fast-json-patch';
+import URI from 'urijs';
 
 import { ModelServerObjectV2, ModelServerReferenceDescriptionV2 } from '../model/base-model';
 import { AnyObject, TypeGuard } from './type-util';
@@ -41,7 +42,7 @@ export interface TypeDefinition {
  * @param value the value to set
  * @returns The Json Patch ReplaceOperation to set the property.
  */
-export function replace<T>(modeluri: string, object: ModelServerObjectV2, feature: string, value: T): ReplaceOperation<T> {
+export function replace<T>(modeluri: URI, object: ModelServerObjectV2, feature: string, value: T): ReplaceOperation<T> {
     return {
         op: REPLACE,
         path: getPropertyPath(modeluri, object, feature),
@@ -59,7 +60,7 @@ export function replace<T>(modeluri: string, object: ModelServerObjectV2, featur
  * @returns The Json Patch AddOperation to create the element.
  */
 export function create(
-    modeluri: string,
+    modeluri: URI,
     parent: ModelServerObjectV2,
     feature: string,
     $type: string,
@@ -84,7 +85,7 @@ export function create(
  * @returns The Json Patch AddOperation to add the element in the parent.
  */
 export function add(
-    modeluri: string,
+    modeluri: URI,
     parent: ModelServerObjectV2,
     feature: string,
     value: ModelServerObjectV2 | ModelServerReferenceDescriptionV2
@@ -105,7 +106,7 @@ export function add(
  * @param object the object to remove from the model
  * @returns The Json Patch RemoveOperation to remove the element.
  */
-export function deleteElement(modeluri: string, object: ModelServerObjectV2): RemoveOperation {
+export function deleteElement(modeluri: URI, object: ModelServerObjectV2): RemoveOperation {
     return {
         op: REMOVE,
         path: getObjectPath(modeluri, object)
@@ -119,7 +120,7 @@ export function deleteElement(modeluri: string, object: ModelServerObjectV2): Re
  * @param feature the property from which a value will be removed
  * @param index the index of the value to remove
  */
-export function removeValueAt(modeluri: string, object: ModelServerObjectV2, feature: string, index: number): RemoveOperation {
+export function removeValueAt(modeluri: URI, object: ModelServerObjectV2, feature: string, index: number): RemoveOperation {
     return {
         op: REMOVE,
         path: getPropertyPath(modeluri, object, feature, index)
@@ -133,7 +134,7 @@ export function removeValueAt(modeluri: string, object: ModelServerObjectV2, fea
  * @param feature the property from which a value will be removed
  * @param value the value to remove
  */
-export function removeValue(modeluri: string, object: ModelServerObjectV2, feature: string, value: AnyObject): RemoveOperation | undefined {
+export function removeValue(modeluri: URI, object: ModelServerObjectV2, feature: string, value: AnyObject): RemoveOperation | undefined {
     const index = findIndex(object, feature, value);
     if (index >= 0) {
         return removeValueAt(modeluri, object, feature, index);
@@ -146,7 +147,7 @@ export function removeValue(modeluri: string, object: ModelServerObjectV2, featu
  * @param modeluri the uri of the model to edit
  * @param objectToRemove the object to delete from the model
  */
-export function removeObject(modeluri: string, objectToRemove: ModelServerObjectV2): RemoveOperation {
+export function removeObject(modeluri: URI, objectToRemove: ModelServerObjectV2): RemoveOperation {
     return {
         op: REMOVE,
         path: getObjectPath(modeluri, objectToRemove)
@@ -163,9 +164,9 @@ export function removeObject(modeluri: string, objectToRemove: ModelServerObject
  * @param object The object.
  * @returns the custom Json Path for this object.
  */
-function getObjectPath(modeluri: string, object: ModelServerObjectV2 | ModelServerReferenceDescriptionV2): string {
+function getObjectPath(modeluri: URI, object: ModelServerObjectV2 | ModelServerReferenceDescriptionV2): string {
     const id = ModelServerReferenceDescriptionV2.is(object) ? object.$ref : object.$id;
-    return `${modeluri}#${id}`;
+    return modeluri.clone().fragment(id).toString();
 }
 
 /**
@@ -180,7 +181,7 @@ function getObjectPath(modeluri: string, object: ModelServerObjectV2 | ModelServ
  * @param index An optional index, for list properties.
  * @returns the custom Json Path to edit this property.
  */
-function getPropertyPath(modeluri: string, object: ModelServerObjectV2, feature: string, index?: number): string {
+function getPropertyPath(modeluri: URI, object: ModelServerObjectV2, feature: string, index?: number): string {
     const indexSuffix = index === undefined ? '' : `/${index}`;
     return `${getObjectPath(modeluri, object)}/${feature}${indexSuffix}`;
 }

--- a/packages/modelserver-client/tsconfig.json
+++ b/packages/modelserver-client/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "lib",
     "reactNamespace": "JSX",
     "baseUrl": "src",
-    "types": ["node", "reflect-metadata", "mocha", "chai"],
+    "types": ["node", "reflect-metadata", "mocha", "chai", "urijs"],
     "esModuleInterop": true
   },
   "include": ["src"]

--- a/packages/modelserver-markers-theia/README.md
+++ b/packages/modelserver-markers-theia/README.md
@@ -6,10 +6,10 @@ The model server client API provides validation methods which manipulate JSON ob
 
 ```typescript
 export interface ModelServerClient extends JsonRpcServer<ModelServerFrontendClient> {
-    validation(modelUri: string): Promise<Response<string>>;
+  validation(modeluri: URI): Promise<Response<string>>;
 
-    // WebSocket connection
-    subscribeWithValidation(modelUri: string): void;
+  // WebSocket connection
+  subscribeWithValidation(modeluri: URI): void;
 }
 ```
 
@@ -25,7 +25,7 @@ After calling the validation, you can create markers as simply as :
 @inject(MessageService) protected readonly messageService: MessageService;
 @inject(DiagnosticManager) protected readonly diagnosticManager: DiagnosticManager;
 
-const modelURI : URI;
+const modelURI : TheiaURI;
 // perform validation
 this.modelServerClient.validation(modelURI.toString())
     .then((response: Response<any>) => {
@@ -36,7 +36,7 @@ this.modelServerClient.validation(modelURI.toString())
         // display the validation status
         this.messageService.info(`Validation finished with level ${Diagnostic.getSeverityLabel(diagnostic)}.`)
     });
-            
+
 ```
 
 ## Selecting the model element from the marker

--- a/packages/modelserver-markers-theia/src/browser/diagnostic-manager.ts
+++ b/packages/modelserver-markers-theia/src/browser/diagnostic-manager.ts
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import { Diagnostic as EMFDiagnostic } from '@eclipse-emfcloud/modelserver-client';
-import URI from '@theia/core/lib/common/uri';
+import { URI as TheiaURI } from '@theia/core/lib/common/uri';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ProblemManager } from '@theia/markers/lib/browser';
 import { Diagnostic as LangServerDiagnostic } from 'vscode-languageserver-types';
@@ -24,33 +24,33 @@ export class DiagnosticManager {
 
     /**
      * Replaces the current markers for the given model URI with markers generated from the given diagnostic.
-     * @param modelUri the model URI concerned by diagnostic
+     * @param modeluri the model URI concerned by diagnostic
      * @param diagnostic the root diagnostic (children diagnostics will be collected if needed)
      */
-    setDiagnostic(modelUri: URI, diagnostic: EMFDiagnostic): void {
+    setDiagnostic(modeluri: TheiaURI, diagnostic: EMFDiagnostic): void {
         const leaves: EMFDiagnostic[] = EMFDiagnostic.collectLeaves(diagnostic);
-        this.setDiagnosticLeaves(modelUri, leaves);
+        this.setDiagnosticLeaves(modeluri, leaves);
     }
 
     /**
      * Replaces the current markers for the given model URI with markers generated from the given diagnostics.
-     * @param modelUri the model URI concerned by diagnostic
+     * @param modeluri the model URI concerned by diagnostic
      * @param diagnostics the diagnostics to take (children diagnostics will be collected if needed)
      */
-    setDiagnostics(modelUri: URI, diagnostics: EMFDiagnostic[]): void {
+    setDiagnostics(modeluri: TheiaURI, diagnostics: EMFDiagnostic[]): void {
         const leavesPerDiagnostic: EMFDiagnostic[][] = diagnostics.map(d => EMFDiagnostic.collectLeaves(d));
         const leaves: EMFDiagnostic[] = leavesPerDiagnostic.reduce((accumulator, values) => accumulator.concat(values), []);
-        this.setDiagnosticLeaves(modelUri, leaves);
+        this.setDiagnosticLeaves(modeluri, leaves);
     }
 
     /**
      * Replaces the current markers for the given model URI with markers generated from the given leaf diagnostics.
-     * @param modelUri the model URI concerned by diagnostic
+     * @param modeluri the model URI concerned by diagnostic
      * @param diagnostics the leaf diagnostics to take as is
      */
-    protected setDiagnosticLeaves(modelUri: URI, diagnostics: EMFDiagnostic[]): void {
+    protected setDiagnosticLeaves(modeluri: TheiaURI, diagnostics: EMFDiagnostic[]): void {
         // first clean old markers
-        this.problemManager.cleanAllMarkers(modelUri);
+        this.problemManager.cleanAllMarkers(modeluri);
         // then convert diagnostics
         const convertedDiagnosticsPerElementId: Map<string, LangServerDiagnostic[]> = new Map();
         diagnostics.forEach(d => {
@@ -65,7 +65,7 @@ export class DiagnosticManager {
         });
         // and log them by element id as owner
         for (const [id, converteds] of convertedDiagnosticsPerElementId) {
-            this.problemManager.setMarkers(modelUri, id, converteds);
+            this.problemManager.setMarkers(modeluri, id, converteds);
         }
     }
 }

--- a/packages/modelserver-theia/README.md
+++ b/packages/modelserver-theia/README.md
@@ -7,44 +7,44 @@ The interface declaration is as defined below. Please note that the `Model` clas
 
 ```typescript
 export interface ModelServerClient extends JsonRpcServer<ModelServerFrontendClient> {
-    initialize(): Promise<boolean>;
+  initialize(): Promise<boolean>;
 
-    get(modelUri: string, format?: string): Promise<Response<string>>;
-    getAll(format?: string): Promise<Response<Model[]>>;
-    getModelUris(): Promise<Response<string[]>>;
+  get(modeluri: URI, format?: string): Promise<Response<string>>;
+  getAll(format?: string): Promise<Response<Model[]>>;
+  getModelUris(): Promise<Response<URI[]>>;
 
-    getElementById(modelUri: string, elementid: string, format?: string): Promise<Response<string>>;
-    getElementByName(modelUri: string, elementname: string, format?: string): Promise<Response<string>>;
+  getElementById(modeluri: URI, elementid: string, format?: string): Promise<Response<string>>;
+  getElementByName(modeluri: URI, elementname: string, format?: string): Promise<Response<string>>;
 
-    delete(modelUri: string): Promise<Response<boolean>>;
-    update(modelUri: string, newModel: any): Promise<Response<string>>;
+  delete(modeluri: URI): Promise<Response<boolean>>;
+  update(modeluri: URI, newModel: any): Promise<Response<string>>;
 
-    configure(configuration?: ServerConfiguration): Promise<Response<boolean>>;
-    ping(): Promise<Response<boolean>>;
+  configure(configuration?: ServerConfiguration): Promise<Response<boolean>>;
+  ping(): Promise<Response<boolean>>;
 
-    undo(modelUri: string): Promise<Response<string>>;
-    redo(modelUri: string): Promise<Response<string>>;
-    save(modelUri: string): Promise<Response<boolean>>;
-    saveAll(): Promise<Response<boolean>>;
+  undo(modeluri: URI): Promise<Response<string>>;
+  redo(modeluri: URI): Promise<Response<string>>;
+  save(modeluri: URI): Promise<Response<boolean>>;
+  saveAll(): Promise<Response<boolean>>;
 
-    getLaunchOptions(): Promise<LaunchOptions>;
+  getLaunchOptions(): Promise<LaunchOptions>;
 
-    edit(modelUri: string, command: ModelServerCommand): Promise<Response<boolean>>;
+  edit(modeluri: URI, command: ModelServerCommand): Promise<Response<boolean>>;
 
-    getTypeSchema(modelUri: string): Promise<Response<string>>;
-    getUiSchema(schemaName: string): Promise<Response<string>>;
+  getTypeSchema(modeluri: URI): Promise<Response<string>>;
+  getUiSchema(schemaName: string): Promise<Response<string>>;
 
-    validation(modelUri: string): Promise<Response<string>>;
-    validationConstraints(modelUri: string): Promise<Response<string>>;
+  validation(modeluri: URI): Promise<Response<string>>;
+  validationConstraints(modeluri: URI): Promise<Response<string>>;
 
-    // WebSocket connection
-    subscribe(modelUri: string): void;
-    subscribeWithValidation(modelUri: string): void;
-    subscribeWithFormat(modelUri: string, format: string): void;
-    subscribeWithTimeout(modelUri: string, timeout: number): void;
-    subscribeWithTimeoutAndFormat(modelUri: string, timeout: number, format: string): void;
-    sendKeepAlive(modelUri: string): void;
-    unsubscribe(modelUri: string): void;
+  // WebSocket connection
+  subscribe(modeluri: URI): void;
+  subscribeWithValidation(modeluri: URI): void;
+  subscribeWithFormat(modeluri: URI, format: string): void;
+  subscribeWithTimeout(modeluri: URI, timeout: number): void;
+  subscribeWithTimeoutAndFormat(modeluri: URI, timeout: number, format: string): void;
+  sendKeepAlive(modeluri: URI): void;
+  unsubscribe(modeluri: URI): void;
 }
 ```
 
@@ -69,7 +69,7 @@ this.modelServerClient.getAll()
 // perform GET ELEMENT
 this.modelServerClient.getElementByName('SuperBrewer3000.json', 'Super Brewer 3000')
     .then((response: Response<any>) => this.messageService.info("GET ELEMENT: " + response.body()));
-            
+
 // perform ADD COMMAND (adds an AutomaticTask to the first Workflow and expects incremental update)
 const owner = {
     'eClass':
@@ -96,5 +96,5 @@ this.modelServerClient.subscribe('SuperBrewer3000.json');
 
 // unsubscribe
 this.modelServerClient.unsubscribe('SuperBrewer3000.json');
-            
+
 ```

--- a/packages/modelserver-theia/package.json
+++ b/packages/modelserver-theia/package.json
@@ -38,9 +38,11 @@
     "@theia/core": "^1.0.0",
     "@theia/process": "^1.0.0",
     "@theia/workspace": "^1.0.0",
+    "urijs": "^1.19.11",
     "ws": "8.5.0"
   },
   "devDependencies": {
+    "@types/urijs": "^1.19.19",
     "rimraf": "^3.0.2",
     "typescript": "^4.6.3"
   },

--- a/packages/modelserver-theia/src/browser/frontend-module.ts
+++ b/packages/modelserver-theia/src/browser/frontend-module.ts
@@ -11,11 +11,12 @@
 import { ModelServerClient, ModelServerClientV2 } from '@eclipse-emfcloud/modelserver-client';
 import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { TheiaModelServerJsonRpcProxyFactory } from '../common/jsonrpc-proxy-factory';
 
 import {
+    ModelServerFrontendClient,
     MODEL_SERVER_CLIENT_SERVICE_PATH,
     MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
-    ModelServerFrontendClient,
     TheiaModelServerClient,
     TheiaModelServerClientV2
 } from '../common';
@@ -33,18 +34,25 @@ export default new ContainerModule(bind => {
     bind(ModelServerSubscriptionClient).toSelf().inSingletonScope();
     bind(ModelServerFrontendClient).toService(ModelServerSubscriptionClient);
     bind(ModelServerSubscriptionService).toService(ModelServerSubscriptionClient);
+
     bind(TheiaModelServerClient)
         .toDynamicValue(ctx => {
             const connection = ctx.container.get(WebSocketConnectionProvider);
             const client: ModelServerFrontendClient = ctx.container.get(ModelServerFrontendClient);
-            return connection.createProxy<ModelServerClient>(MODEL_SERVER_CLIENT_SERVICE_PATH, client);
+            return connection.createProxy<ModelServerClient>(
+                MODEL_SERVER_CLIENT_SERVICE_PATH,
+                new TheiaModelServerJsonRpcProxyFactory(client)
+            );
         })
         .inSingletonScope();
     bind(TheiaModelServerClientV2)
         .toDynamicValue(ctx => {
             const connection = ctx.container.get(WebSocketConnectionProvider);
             const client: ModelServerFrontendClient = ctx.container.get(ModelServerFrontendClient);
-            return connection.createProxy<ModelServerClientV2>(MODEL_SERVER_CLIENT_V2_SERVICE_PATH, client);
+            return connection.createProxy<ModelServerClientV2>(
+                MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
+                new TheiaModelServerJsonRpcProxyFactory(client)
+            );
         })
         .inSingletonScope();
 });

--- a/packages/modelserver-theia/src/common/jsonrpc-proxy-factory.ts
+++ b/packages/modelserver-theia/src/common/jsonrpc-proxy-factory.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+
+import { asURI, isURI } from '@eclipse-emfcloud/modelserver-client/lib/utils/type-util';
+import { JsonRpcProxyFactory } from '@theia/core/lib/common/messaging/proxy-factory';
+import URI from 'urijs';
+
+export class TheiaModelServerJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T> {
+    protected override async onRequest(method: string, ...args: any[]): Promise<any> {
+        return super.onRequest(method, ...this.processArguments(args));
+    }
+
+    protected override onNotification(method: string, ...args: any[]): void {
+        super.onNotification(method, ...this.processArguments(args));
+    }
+
+    protected processArguments(args: any[]): any[] {
+        const processedArgs: any[] = [];
+        for (const arg of args) {
+            if (isURI(arg)) {
+                processedArgs.push(new URI(asURI(arg)));
+            } else {
+                processedArgs.push(arg);
+            }
+        }
+        return processedArgs;
+    }
+}

--- a/packages/modelserver-theia/src/common/protocol.ts
+++ b/packages/modelserver-theia/src/common/protocol.ts
@@ -16,16 +16,17 @@ import {
 } from '@eclipse-emfcloud/modelserver-client';
 import { JsonRpcServer } from '@theia/core';
 import WebSocket from 'isomorphic-ws';
+import URI from 'urijs';
 
 export const MODEL_SERVER_CLIENT_SERVICE_PATH = '/services/modelserverclient';
 export const MODEL_SERVER_CLIENT_V2_SERVICE_PATH = '/services/modelserverclient/v2';
 
 export const ModelServerFrontendClient = Symbol('ModelServerFrontendClient');
 export interface ModelServerFrontendClient {
-    onOpen(modelUri: string, event: WebSocket.Event): void;
-    onClose(modelUri: string, event: WebSocket.CloseEvent): void;
-    onError(modelUri: string, event: WebSocket.ErrorEvent): void;
-    onMessage(modelUri: string, event: WebSocket.MessageEvent): void;
+    onOpen(modeluri: URI, event: WebSocket.Event): void;
+    onClose(modeluri: URI, event: WebSocket.CloseEvent): void;
+    onError(modeluri: URI, event: WebSocket.ErrorEvent): void;
+    onMessage(modeluri: URI, event: WebSocket.MessageEvent): void;
 }
 
 export const TheiaModelServerClient = Symbol('TheiaModelServerClient');
@@ -42,7 +43,7 @@ export interface TheiaModelServerClientV2 extends ModelServerClientApiV2, JsonRp
      * client handle both Theia RPC events and the messages from the _Model Server_
      * @param options optional subscription options, including message format, time-out, and message filtering
      */
-    subscribe(modeluri: string, listener?: SubscriptionListener, options?: SubscriptionOptionsV2): SubscriptionListener;
+    subscribe(modeluri: URI, listener?: SubscriptionListener, options?: SubscriptionOptionsV2): SubscriptionListener;
 
     /**
      * Subscribe the frontend client of the remote `TheiaModelServerClientV2` service as
@@ -52,5 +53,5 @@ export interface TheiaModelServerClientV2 extends ModelServerClientApiV2, JsonRp
      * @param modeluri the URI of the model to which to subscribe
      * @param options optional subscription options, including message format, time-out, and message filtering
      */
-    selfSubscribe(modeluri: string, options?: SubscriptionOptionsV2): void;
+    selfSubscribe(modeluri: URI, options?: SubscriptionOptionsV2): void;
 }

--- a/packages/modelserver-theia/src/node/backend-module.ts
+++ b/packages/modelserver-theia/src/node/backend-module.ts
@@ -13,12 +13,13 @@ import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { ContainerModule } from '@theia/core/shared/inversify';
 
 import {
+    ModelServerFrontendClient,
     MODEL_SERVER_CLIENT_SERVICE_PATH,
     MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
-    ModelServerFrontendClient,
     TheiaModelServerClient,
     TheiaModelServerClientV2
 } from '../common';
+import { TheiaModelServerJsonRpcProxyFactory } from '../common/jsonrpc-proxy-factory';
 import { LaunchOptions } from './launch-options';
 import { DefaultModelServerLauncher, DefaultModelServerNodeLauncher, ModelServerLauncher } from './model-server-backend-contribution';
 import { TheiaBackendModelServerClient } from './theia-model-server-client';
@@ -41,12 +42,16 @@ export default new ContainerModule(bind => {
     bind(ConnectionHandler)
         .toDynamicValue(
             ctx =>
-                new JsonRpcConnectionHandler<ModelServerFrontendClient>(MODEL_SERVER_CLIENT_SERVICE_PATH, client => {
-                    const modelServerClient = ctx.container.get<TheiaModelServerClient>(TheiaModelServerClient);
-                    modelServerClient.setClient(client);
-                    client.onDidCloseConnection(() => modelServerClient.dispose());
-                    return modelServerClient;
-                })
+                new JsonRpcConnectionHandler<ModelServerFrontendClient>(
+                    MODEL_SERVER_CLIENT_SERVICE_PATH,
+                    client => {
+                        const modelServerClient = ctx.container.get<TheiaModelServerClient>(TheiaModelServerClient);
+                        modelServerClient.setClient(client);
+                        client.onDidCloseConnection(() => modelServerClient.dispose());
+                        return modelServerClient;
+                    },
+                    TheiaModelServerJsonRpcProxyFactory
+                )
         )
         .inSingletonScope();
 
@@ -55,12 +60,16 @@ export default new ContainerModule(bind => {
     bind(ConnectionHandler)
         .toDynamicValue(
             ctx =>
-                new JsonRpcConnectionHandler<ModelServerFrontendClient>(MODEL_SERVER_CLIENT_V2_SERVICE_PATH, client => {
-                    const modelServerClient = ctx.container.get<TheiaModelServerClientV2>(TheiaModelServerClientV2);
-                    modelServerClient.setClient(client);
-                    client.onDidCloseConnection(() => modelServerClient.dispose());
-                    return modelServerClient;
-                })
+                new JsonRpcConnectionHandler<ModelServerFrontendClient>(
+                    MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
+                    client => {
+                        const modelServerClient = ctx.container.get<TheiaModelServerClientV2>(TheiaModelServerClientV2);
+                        modelServerClient.setClient(client);
+                        client.onDidCloseConnection(() => modelServerClient.dispose());
+                        return modelServerClient;
+                    },
+                    TheiaModelServerJsonRpcProxyFactory
+                )
         )
         .inSingletonScope();
 });

--- a/packages/modelserver-theia/src/node/launch-options.ts
+++ b/packages/modelserver-theia/src/node/launch-options.ts
@@ -50,7 +50,7 @@ export interface ModelServerNodeOptions {
 }
 
 export const DEFAULT_LAUNCH_OPTIONS: LaunchOptions = {
-    baseURL: 'api/v1',
+    baseURL: 'api/v2',
     serverPort: 8081,
     hostname: 'localhost'
 };

--- a/packages/modelserver-theia/src/node/theia-model-server-client.ts
+++ b/packages/modelserver-theia/src/node/theia-model-server-client.ts
@@ -10,6 +10,7 @@
  *******************************************************************************/
 import { ModelServerClient, SubscriptionOptions } from '@eclipse-emfcloud/modelserver-client';
 import { decorate, inject, injectable, optional } from '@theia/core/shared/inversify';
+import URI from 'urijs';
 import { CancellationToken } from 'vscode-jsonrpc';
 
 import { ModelServerFrontendClient, TheiaModelServerClient } from '../common';
@@ -25,8 +26,13 @@ export class TheiaBackendModelServerClient extends ModelServerClient implements 
         this.initialize(baseUrl);
     }
 
-    protected getBaseUrl(): string {
-        const baseUrl = `http://${this.launchOptions.hostname}:${this.launchOptions.serverPort}/${this.launchOptions.baseURL}`;
+    protected getBaseUrl(): URI {
+        const baseUrl = new URI({
+            protocol: 'http',
+            hostname: this.launchOptions.hostname,
+            port: this.launchOptions.serverPort,
+            path: this.launchOptions.baseURL
+        });
         return baseUrl;
     }
 
@@ -36,7 +42,7 @@ export class TheiaBackendModelServerClient extends ModelServerClient implements 
         this.subscriptionClient = client;
     }
 
-    subscribe(modeluri: string, options: SubscriptionOptions = {}): void {
+    subscribe(modeluri: URI, options: SubscriptionOptions = {}): void {
         // Handle optional arguments finding the RPC cancellation token in their place
         if (CancellationToken.is(options)) {
             options = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,6 +3136,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
+"@types/urijs@^1.19.19":
+  version "1.19.19"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
+  integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
+
 "@types/uuid@^7.0.3":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.5.tgz#b1d2f772142a301538fae9bdf9cf15b9f2573a29"
@@ -5427,11 +5432,6 @@ eslint-plugin-prettier@^4.0.0:
   integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
-
-eslint-plugin-simple-import-sort@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
-  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -10979,6 +10979,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+urijs@^1.19.11:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 url-parse@^1.5.3:
   version "1.5.10"


### PR DESCRIPTION
Consistently use URI object in APIs

- Use `urijs` as typed URI library
- Use URI objects in APIs and internally for proper URI handling
  - Adapt interfaces, tests
- Customize JsonRpcProxyFactory to ensure URI object is correctly typed onRequest/onNotifciation
  - Configure on backend and frontend for the JsonRpc WebSocketConnection
- Rename modeluri to lowercase where applicable for better alignment
- Differentiate URI and TheiaURI object
- Update README examples

Update dev-example to ModelServerClient V2

- Update custom DevModelServerClient
- Update api-test-menu
  - User URIs to trigger commands
  - Refine notification printing
  - Add test commands that edit via JSON patch commands
  - Remove xmi test commands as they are not relevant anymore
 
General
- Remove simple-import-sort eslint plugin as it interferes with the built-in import sort
- Ignore zipped rolling log files
- Fix launch configs

Part of https://github.com/eclipse-emfcloud/emfcloud/issues/179

Contributed on behalf of STMicroelectronics