### PR TITLE
Allow to set a mono containment reference (#52)

### DIFF
--- a/packages/modelserver-client/src/model/command-model.ts
+++ b/packages/modelserver-client/src/model/command-model.ts
@@ -133,11 +133,13 @@ export class SetCommand extends ModelServerCommand {
     constructor(
         public owner: ModelServerReferenceDescription,
         public feature: string,
-        changedValues: DataValueType[] | ModelServerReferenceDescription[]
+        changedValues: DataValueType[] | ModelServerReferenceDescription[] | ModelServerObject[]
     ) {
         super(SetCommand.TYPE);
         if (isModelServerReferenceDescriptionArray(changedValues)) {
             this.objectValues = changedValues;
+        } else if (isModelServerObjectArray(changedValues)) {
+            this.objectsToAdd = changedValues;
         } else {
             this.dataValues = changedValues;
         }

--- a/packages/modelserver-client/src/utils/model-server-utils.ts
+++ b/packages/modelserver-client/src/utils/model-server-utils.ts
@@ -19,7 +19,7 @@ export function isModelServerObjectArray(array: Array<DataValueType | ModelServe
 }
 
 export function isModelServerReferenceDescriptionArray(
-    array: Array<DataValueType | ModelServerReferenceDescription>
+    array: Array<DataValueType | ModelServerReferenceDescription | ModelServerObject>
 ): array is ModelServerReferenceDescription[] {
     return array.every(ModelServerReferenceDescription.is);
 }


### PR DESCRIPTION
Let user build a "SetCommand" with model objects for containment ref. This SetCommand must be correctly interpreted by server.

Signed-off-by: vhemery <vincent.hemery@bonitasoft.com>

Should be merged after https://github.com/eclipse-emfcloud/emfcloud-modelserver/pull/258