### PR TITLE
#179 Use URIs in workspace configuration

### DIFF
--- a/packages/modelserver-client/src/model-server-client-api-v1.ts
+++ b/packages/modelserver-client/src/model-server-client-api-v1.ts
@@ -10,9 +10,9 @@
  *******************************************************************************/
 import URI from 'urijs';
 
+import { MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
 import { ModelServerCommand } from './model/command-model';
 import { Diagnostic } from './model/diagnostic';
-import { MessageDataMapper, Model, ModelServerMessage } from './model-server-message';
 import { SubscriptionListener } from './subscription-listener';
 import { AnyObject, TypeGuard } from './utils/type-util';
 
@@ -334,8 +334,8 @@ export interface SubscriptionOptions {
  * the workspaceRoot and the ui schema folder.
  */
 export interface ServerConfiguration {
-    workspaceRoot: string;
-    uiSchemaFolder?: string;
+    workspaceRoot: URI;
+    uiSchemaFolder?: URI;
 }
 
 /**

--- a/packages/modelserver-client/src/model-server-client-v2.spec.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.spec.ts
@@ -269,14 +269,19 @@ describe('tests for ModelServerClientV2', () => {
 
         it('configureServer', done => {
             const configuration: ServerConfiguration = {
-                workspaceRoot: 'myRoot',
-                uiSchemaFolder: 'mySchemaFolder'
+                workspaceRoot: new URI('myRoot'),
+                uiSchemaFolder: new URI('mySchemaFolder')
             };
             client.configureServer(configuration);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('put');
-                expect(request.config.data).to.equal(JSON.stringify(configuration));
+                expect(request.config.data).to.equal(
+                    JSON.stringify({
+                        workspaceRoot: configuration.workspaceRoot.toString(),
+                        uiSchemaFolder: configuration.uiSchemaFolder!.toString()
+                    })
+                );
                 expect(request.config.params).to.be.undefined;
                 expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);

--- a/packages/modelserver-client/src/model-server-client-v2.ts
+++ b/packages/modelserver-client/src/model-server-client-v2.ts
@@ -225,11 +225,11 @@ export class ModelServerClientV2 implements ModelServerClientApiV2 {
     }
 
     configureServer(configuration: ServerConfiguration): Promise<boolean> {
-        let { workspaceRoot, uiSchemaFolder } = configuration;
-        workspaceRoot = workspaceRoot.replace('file://', '');
-        uiSchemaFolder = uiSchemaFolder?.replace('file://', '');
         return this.process(
-            this.restClient.put(ModelServerPaths.SERVER_CONFIGURE, { workspaceRoot, uiSchemaFolder }),
+            this.restClient.put(ModelServerPaths.SERVER_CONFIGURE, {
+                workspaceRoot: configuration.workspaceRoot.toString(),
+                uiSchemaFolder: configuration.uiSchemaFolder?.toString()
+            }),
             MessageDataMapper.isSuccess
         );
     }

--- a/packages/modelserver-client/src/model-server-client.spec.ts
+++ b/packages/modelserver-client/src/model-server-client.spec.ts
@@ -268,14 +268,19 @@ describe('tests for ModelServerClient', () => {
 
         it('configureServer', done => {
             const configuration: ServerConfiguration = {
-                workspaceRoot: 'myRoot',
-                uiSchemaFolder: 'mySchemaFolder'
+                workspaceRoot: new URI('myRoot'),
+                uiSchemaFolder: new URI('mySchemaFolder')
             };
             client.configureServer(configuration);
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 expect(request.config.method).to.be.equal('put');
-                expect(request.config.data).to.equal(JSON.stringify(configuration));
+                expect(request.config.data).to.equal(
+                    JSON.stringify({
+                        workspaceRoot: configuration.workspaceRoot.toString(),
+                        uiSchemaFolder: configuration.uiSchemaFolder!.toString()
+                    })
+                );
                 expect(request.config.params).to.be.undefined;
                 expect(request.config.baseURL).to.be.equal(baseUrl.toString());
                 expect(request.config.url).to.be.equal(ModelServerPaths.SERVER_CONFIGURE);

--- a/packages/modelserver-client/src/model-server-client.ts
+++ b/packages/modelserver-client/src/model-server-client.ts
@@ -146,11 +146,11 @@ export class ModelServerClient implements ModelServerClientApiV1 {
     }
 
     configureServer(configuration: ServerConfiguration): Promise<boolean> {
-        let { workspaceRoot, uiSchemaFolder } = configuration;
-        workspaceRoot = workspaceRoot.replace('file://', '');
-        uiSchemaFolder = uiSchemaFolder?.replace('file://', '');
         return this.process(
-            this.restClient.put(ModelServerPaths.SERVER_CONFIGURE, { workspaceRoot, uiSchemaFolder }),
+            this.restClient.put(ModelServerPaths.SERVER_CONFIGURE, {
+                workspaceRoot: configuration.workspaceRoot.toString(),
+                uiSchemaFolder: configuration.uiSchemaFolder?.toString()
+            }),
             MessageDataMapper.isSuccess
         );
     }

--- a/packages/modelserver-theia/src/browser/model-server-frontend-contribution.ts
+++ b/packages/modelserver-theia/src/browser/model-server-frontend-contribution.ts
@@ -12,23 +12,24 @@ import { MaybePromise } from '@theia/core';
 import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import URI from 'urijs';
 
-import { TheiaModelServerClient } from '../common';
+import { TheiaModelServerClientV2 } from '../common';
 
 @injectable()
 export class ModelServerFrontendContribution implements FrontendApplicationContribution {
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
-    @inject(TheiaModelServerClient) protected readonly modelServerClient: TheiaModelServerClient;
+    @inject(TheiaModelServerClientV2) protected readonly modelServerClient: TheiaModelServerClientV2;
 
-    configure(app: FrontendApplication): MaybePromise<void> {
+    configure(_app: FrontendApplication): MaybePromise<void> {
         return this.setup();
     }
 
     async setup(): Promise<void> {
         this.workspaceService.onWorkspaceChanged(workspace => {
             if (workspace[0] && workspace[0].resource) {
-                const workspaceRoot = workspace[0].resource.toString();
-                const uiSchemaFolder = workspaceRoot + '/.ui-schemas';
+                const workspaceRoot = new URI(workspace[0].resource.toString());
+                const uiSchemaFolder = workspaceRoot.clone().segment('.ui-schemas');
                 this.modelServerClient.configureServer({ workspaceRoot, uiSchemaFolder });
             }
         });


### PR DESCRIPTION
- Ensure workspace configurations are URIs
- Remove file uri manipulation of workspace configurations
- Update TheiaModelServerJsonRpcProxyFactory to properly forward arguments that are URI arrays or objects that hold URI values (such as the workspace configuration object)
- Update tests

Contributed on behalf of STMicroelectronics

Part of https://github.com/eclipse-emfcloud/emfcloud/issues/179