### PR TITLE
#179 Use URIs in DiagnosticManager

### DIFF
--- a/examples/dev-example/src/browser/api-test-menu.ts
+++ b/examples/dev-example/src/browser/api-test-menu.ts
@@ -34,7 +34,6 @@ import {
     MessageType as MessageLevel
 } from '@theia/core';
 import { ConfirmDialog } from '@theia/core/lib/browser';
-import { URI as TheiaURI } from '@theia/core/lib/common/uri';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { Operation } from 'fast-json-patch';
 import URI from 'urijs';
@@ -701,7 +700,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationMarkersCommand, {
             execute: () => {
                 this.modelServerClient.validate(new URI('SuperBrewer3000.coffee')).then(result => {
-                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new TheiaURI('SuperBrewer3000.coffee'), result);
+                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new URI('SuperBrewer3000.coffee'), result);
                     this.messageService.info(message);
                 });
             }
@@ -844,7 +843,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationMarkersCoffeeEcoreCommand, {
             execute: () => {
                 this.modelServerClient.validate(new URI('Coffee.ecore')).then(result => {
-                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new TheiaURI('Coffee.ecore'), result);
+                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new URI('Coffee.ecore'), result);
                     this.messageService.info(message);
                 });
             }
@@ -1005,7 +1004,7 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
         commands.registerCommand(ValidationMarkersSuperBrewer3000JsonCommand, {
             execute: () => {
                 this.modelServerClient.validate(new URI('SuperBrewer3000.json')).then(result => {
-                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new TheiaURI('SuperBrewer3000.json'), result);
+                    const message = createMarkersFromDiagnostic(this.diagnosticManager, new URI('SuperBrewer3000.json'), result);
                     this.messageService.info(message);
                 });
             }
@@ -1183,13 +1182,13 @@ export class ApiTestMenuContribution implements MenuContribution, CommandContrib
 /**
  * Create the markers in the problem view
  * @param diagnosticManager the diagnostic manager
- * @param theiaURI the concerned model URI
+ * @param modeluri the concerned model URI
  * @param response the validation response
  * @returns the message to log
  */
-function createMarkersFromDiagnostic(diagnosticManager: DiagnosticManager, theiaURI: TheiaURI, diagnostic: Diagnostic): string {
+function createMarkersFromDiagnostic(diagnosticManager: DiagnosticManager, modeluri: URI, diagnostic: Diagnostic): string {
     // print markers in Problems view
-    diagnosticManager.setDiagnostic(theiaURI, diagnostic);
+    diagnosticManager.setDiagnostic(modeluri, diagnostic);
     const level = Diagnostic.getSeverityLabel(diagnostic);
     if (level === 'OK') {
         return `Validation is ${level}. There should be no new marker in Problems view.`;

--- a/packages/modelserver-client/src/utils/index.ts
+++ b/packages/modelserver-client/src/utils/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2022 EclipseSource and others.
+ * Copyright (c) 2022 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -8,5 +8,4 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-export * from './jsonrpc-proxy-factory';
-export * from './protocol';
+export * as URIUtils from './uri-utils';

--- a/packages/modelserver-client/src/utils/uri-utils.ts
+++ b/packages/modelserver-client/src/utils/uri-utils.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+import { URI as TheiaURI } from '@theia/core/lib/common/uri';
+import URI from 'urijs';
+
+/**
+ * Converts the given TheiaURI to an URI object
+ * @param theiaUri the Theia uri to be converted
+ * @returns the converted URI
+ */
+export function convertToUri(theiaUri: TheiaURI): URI {
+    return new URI(theiaUri.toString(true)).normalize();
+}
+
+/**
+ * Converts the given URI to a TheiaURI object
+ * @param uri the uri to be converted
+ * @returns the converted TheiaURI
+ */
+export function convertToTheiaUri(uri: URI): TheiaURI {
+    return new TheiaURI(uri.toString());
+}

--- a/packages/modelserver-markers-theia/README.md
+++ b/packages/modelserver-markers-theia/README.md
@@ -25,7 +25,7 @@ After calling the validation, you can create markers as simply as :
 @inject(MessageService) protected readonly messageService: MessageService;
 @inject(DiagnosticManager) protected readonly diagnosticManager: DiagnosticManager;
 
-const modelURI : TheiaURI;
+const modelURI : URI;
 // perform validation
 this.modelServerClient.validation(modelURI.toString())
     .then((response: Response<any>) => {

--- a/packages/modelserver-theia/src/browser/frontend-module.ts
+++ b/packages/modelserver-theia/src/browser/frontend-module.ts
@@ -11,14 +11,14 @@
 import { ModelServerClient, ModelServerClientV2 } from '@eclipse-emfcloud/modelserver-client';
 import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { TheiaModelServerJsonRpcProxyFactory } from '../common/jsonrpc-proxy-factory';
 
 import {
     ModelServerFrontendClient,
     MODEL_SERVER_CLIENT_SERVICE_PATH,
     MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
     TheiaModelServerClient,
-    TheiaModelServerClientV2
+    TheiaModelServerClientV2,
+    TheiaModelServerJsonRpcProxyFactory
 } from '../common';
 import { ModelServerFrontendContribution } from './model-server-frontend-contribution';
 import {

--- a/packages/modelserver-theia/src/node/backend-module.ts
+++ b/packages/modelserver-theia/src/node/backend-module.ts
@@ -17,9 +17,9 @@ import {
     MODEL_SERVER_CLIENT_SERVICE_PATH,
     MODEL_SERVER_CLIENT_V2_SERVICE_PATH,
     TheiaModelServerClient,
-    TheiaModelServerClientV2
+    TheiaModelServerClientV2,
+    TheiaModelServerJsonRpcProxyFactory
 } from '../common';
-import { TheiaModelServerJsonRpcProxyFactory } from '../common/jsonrpc-proxy-factory';
 import { LaunchOptions } from './launch-options';
 import { DefaultModelServerLauncher, DefaultModelServerNodeLauncher, ModelServerLauncher } from './model-server-backend-contribution';
 import { TheiaBackendModelServerClient } from './theia-model-server-client';


### PR DESCRIPTION
- Ensure URIs are used in DiagnosticManager and convert to TheiaURI if handing over to the problemManager
- Provide basic URIUtil functions for conversion to/from TheiaURIs
- Export TheiaModelServerJsonRpcProxyFactory properly from the containing common package

Contributed on behalf of STMicroelectronics

Part of https://github.com/eclipse-emfcloud/emfcloud/issues/179