### PR TITLE
#129 Keep URI (urijs) usage to a minimum for Theia related packages

### DIFF
--- a/packages/modelserver-markers-theia/src/browser/diagnostic-manager.ts
+++ b/packages/modelserver-markers-theia/src/browser/diagnostic-manager.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2022 CS GROUP - France and others.
+ * Copyright (c) 2021-2023 CS GROUP - France and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,10 +9,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 import { Diagnostic as EMFDiagnostic } from '@eclipse-emfcloud/modelserver-client';
-import { URIUtils } from '@eclipse-emfcloud/modelserver-client/lib/utils';
+import { URI as TheiaURI } from '@theia/core/lib/common/uri';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ProblemManager } from '@theia/markers/lib/browser';
-import URI from 'urijs';
 import { Diagnostic as LangServerDiagnostic } from 'vscode-languageserver-types';
 
 import { DiagnosticAdapter } from './diagnostic-adapter';
@@ -28,7 +27,7 @@ export class DiagnosticManager {
      * @param modeluri the model URI concerned by diagnostic
      * @param diagnostic the root diagnostic (children diagnostics will be collected if needed)
      */
-    setDiagnostic(modeluri: URI, diagnostic: EMFDiagnostic): void {
+    setDiagnostic(modeluri: TheiaURI, diagnostic: EMFDiagnostic): void {
         const leaves: EMFDiagnostic[] = EMFDiagnostic.collectLeaves(diagnostic);
         this.setDiagnosticLeaves(modeluri, leaves);
     }
@@ -38,7 +37,7 @@ export class DiagnosticManager {
      * @param modeluri the model URI concerned by diagnostic
      * @param diagnostics the diagnostics to take (children diagnostics will be collected if needed)
      */
-    setDiagnostics(modeluri: URI, diagnostics: EMFDiagnostic[]): void {
+    setDiagnostics(modeluri: TheiaURI, diagnostics: EMFDiagnostic[]): void {
         const leavesPerDiagnostic: EMFDiagnostic[][] = diagnostics.map(d => EMFDiagnostic.collectLeaves(d));
         const leaves: EMFDiagnostic[] = leavesPerDiagnostic.reduce((accumulator, values) => accumulator.concat(values), []);
         this.setDiagnosticLeaves(modeluri, leaves);
@@ -49,9 +48,9 @@ export class DiagnosticManager {
      * @param modeluri the model URI concerned by diagnostic
      * @param diagnostics the leaf diagnostics to take as is
      */
-    protected setDiagnosticLeaves(modeluri: URI, diagnostics: EMFDiagnostic[]): void {
+    protected setDiagnosticLeaves(modeluri: TheiaURI, diagnostics: EMFDiagnostic[]): void {
         // first clean old markers
-        this.problemManager.cleanAllMarkers(URIUtils.convertToTheiaUri(modeluri));
+        this.problemManager.cleanAllMarkers(modeluri);
         // then convert diagnostics
         const convertedDiagnosticsPerElementId: Map<string, LangServerDiagnostic[]> = new Map();
         diagnostics.forEach(d => {
@@ -66,7 +65,7 @@ export class DiagnosticManager {
         });
         // and log them by element id as owner
         for (const [id, converteds] of convertedDiagnosticsPerElementId) {
-            this.problemManager.setMarkers(URIUtils.convertToTheiaUri(modeluri), id, converteds);
+            this.problemManager.setMarkers(modeluri, id, converteds);
         }
     }
 }


### PR DESCRIPTION
Update existing API for Theia-related packages to use Theia's URI type
- package modelserver-markers-theia
  - update DiagnosticManager to use TheiaUri in API internally
  - update usage of DiagnosticManager

Resolves #129

Contributed on behalf of STMicroelectronics