### PR TITLE
#194 Align ws dependency version with @theia/core

### DIFF
--- a/packages/modelserver-client/package.json
+++ b/packages/modelserver-client/package.json
@@ -45,7 +45,7 @@
     "fast-json-patch": "^3.1.0",
     "isomorphic-ws": "^4.0.1",
     "urijs": "^1.19.11",
-    "ws": "^8.5.0"
+    "ws": "^7.1.2"
   },
   "devDependencies": {
     "@types/moxios": "0.4.14",

--- a/packages/modelserver-theia/package.json
+++ b/packages/modelserver-theia/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@eclipse-emfcloud/modelserver-client": "0.7.0",
     "urijs": "^1.19.11",
-    "ws": "^8.5.0"
+    "ws": "^7.1.2"
   },
   "peerDependencies": {
     "@theia/core": "^1.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11453,11 +11453,6 @@ ws@^7.1.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
-ws@^8.5.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
-  integrity sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==
-
 ws@~8.2.3:
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"


### PR DESCRIPTION
- Align the `ws` dependency version with Theia's version `^7.1.2`
- The newer version (>8) seems to have breaking changes regarding the `MessageEvent`. This could not be serialized anymore `onMessage` notifications
  - See also https://github.com/websockets/ws/releases/tag/8.0.0

Follow-up of #136