### PR TITLE
Wait for model server ready during startup

### DIFF
--- a/packages/modelserver-theia/src/browser/model-server-frontend-contribution.ts
+++ b/packages/modelserver-theia/src/browser/model-server-frontend-contribution.ts
@@ -10,6 +10,7 @@
  *******************************************************************************/
 import { MaybePromise } from '@theia/core';
 import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { timeout } from '@theia/core/lib/common/promise-util';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import URI from 'urijs';
@@ -26,12 +27,27 @@ export class ModelServerFrontendContribution implements FrontendApplicationContr
     }
 
     async setup(): Promise<void> {
-        this.workspaceService.onWorkspaceChanged(workspace => {
+        this.workspaceService.onWorkspaceChanged(async workspace => {
             if (workspace[0] && workspace[0].resource) {
                 const workspaceRoot = new URI(workspace[0].resource.toString());
                 const uiSchemaFolder = workspaceRoot.clone().segment('.ui-schemas');
-                this.modelServerClient.configureServer({ workspaceRoot, uiSchemaFolder });
+                await this.waitForReady();
+                console.log('Model Server ready');
+                await this.modelServerClient.configureServer({ workspaceRoot, uiSchemaFolder });
             }
         });
+    }
+
+    async waitForReady(ms = 1000): Promise<void> {
+        let available = await this.modelServerClient.ping().catch(e => {
+            console.log('Model Server not ready yet: ' + e);
+        });
+        while (!available) {
+            await timeout(ms);
+            available = await this.modelServerClient.ping().catch(e => {
+                console.log('Model Server not ready yet: ' + e);
+            });
+        }
+        return;
     }
 }


### PR DESCRIPTION
With this change the FrontendApplication will wait until the model server is ready before it can be loaded.
This is useful, as the application can then be sure that the model server is ready to be used.